### PR TITLE
Respond with total items and errors.

### DIFF
--- a/pkg/database/batch.go
+++ b/pkg/database/batch.go
@@ -1,0 +1,116 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package database
+
+import (
+	"context"
+	"sync"
+
+	pgx "github.com/jackc/pgx/v4"
+	"github.com/stolostron/search-indexer/pkg/model"
+	"k8s.io/klog/v2"
+)
+
+// This is a wrapper for pgx.Batch
+// We need this because pgx.Batch doesn't provide a way to retry batches with errors.
+
+type batchItem struct {
+	action string // Used to report errors.
+	query  string
+	args   []interface{}
+	uid    string // Used to report errors.
+}
+
+type batchWithRetry struct {
+	items        []batchItem
+	dao          *DAO
+	wg           *sync.WaitGroup
+	syncResponse *model.SyncResponse
+}
+
+func NewBatchWithRetry(dao *DAO, syncResponse *model.SyncResponse) batchWithRetry {
+	batch := batchWithRetry{
+		items:        make([]batchItem, 0),
+		wg:           &sync.WaitGroup{},
+		dao:          dao,
+		syncResponse: syncResponse,
+	}
+	return batch
+}
+
+func (b *batchWithRetry) Queue(item batchItem) {
+	b.items = append(b.items, item)
+
+	if len(b.items) >= b.dao.batchSize {
+		items := b.items               // Create a snapshot of the items to process.
+		b.items = make([]batchItem, 0) // Reset the queue.
+		b.wg.Add(1)
+		go b.sendBatch(items)
+	}
+}
+
+func (b *batchWithRetry) sendBatch(items []batchItem) error {
+	defer b.wg.Done()
+
+	batch := &pgx.Batch{}
+	for _, item := range items {
+		batch.Queue(item.query, item.args...)
+	}
+	br := b.dao.pool.SendBatch(context.Background(), batch)
+	_, err := br.Exec()
+	br.Close()
+
+	// Process errors.
+	// pgx.Batch is processed as a transaction, so in case of an error, the entire batch will fail.
+	if err != nil && len(items) == 1 {
+
+		item := items[0]
+		klog.Errorf("ERROR processing batchItem.  %+v", items[0])
+
+		var errorArray *[]model.SyncError
+		switch item.action {
+		case "addResource":
+			errorArray = &b.syncResponse.AddErrors
+		case "updateResource":
+			errorArray = &b.syncResponse.UpdateErrors
+		case "deleteResource":
+			errorArray = &b.syncResponse.DeleteErrors
+		case "addEdge":
+			errorArray = &b.syncResponse.AddEdgeErrors
+		case "deleteEdge":
+			errorArray = &b.syncResponse.DeleteEdgeErrors
+		default:
+			klog.Error("Unable to process sync error with type: ", item.action)
+		}
+		*errorArray = append(*errorArray, model.SyncError{ResourceUID: items[0].uid, Message: "Error details"})
+
+		return nil // Don't return error here to stop the recursion.
+	} else if err != nil {
+		// Error sending batch, resending in smaller batches.
+
+		// Retry first half.
+		firstHalf := items[:len(items)/2]
+		b.wg.Add(1)
+		err1 := b.sendBatch(firstHalf)
+
+		// Retry second half
+		secondHalf := items[len(items)/2:]
+		b.wg.Add(1)
+		err2 := b.sendBatch(secondHalf)
+
+		// Returns error only if we fail processing either retry.
+		if err1 != nil && err2 != nil {
+			return nil
+		}
+	}
+	return err
+}
+
+func (b *batchWithRetry) flush() {
+	if len(b.items) > 0 {
+		items := b.items               // Create a snapshot of the items to process.
+		b.items = make([]batchItem, 0) // Reset the queue.
+		b.wg.Add(1)
+		go b.sendBatch(items)
+	}
+}

--- a/pkg/database/dataValidation.go
+++ b/pkg/database/dataValidation.go
@@ -1,0 +1,33 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package database
+
+import (
+	"context"
+
+	pgx "github.com/jackc/pgx/v4"
+	"k8s.io/klog/v2"
+)
+
+// Query resource and edge count for a cluster. Used for data validation.
+func (dao *DAO) ClusterTotals(clusterName string) (resources int, edges int) {
+	batch := &pgx.Batch{}
+	batch.Queue("SELECT count(*) FROM search.resources WHERE cluster=$1", clusterName)
+	batch.Queue("SELECT count(*) FROM search.edges WHERE cluster=$1", clusterName)
+
+	br := dao.pool.SendBatch(context.Background(), batch)
+	defer br.Close()
+
+	resourcesRow := br.QueryRow()
+	resourcesErr := resourcesRow.Scan(&resources)
+	if resourcesErr != nil {
+		klog.Error("Error reading total resources for cluster ", clusterName)
+	}
+	edgesRow := br.QueryRow()
+	edgesErr := edgesRow.Scan(&edges)
+	if edgesErr != nil {
+		klog.Error("Error reading total edges for cluster ", clusterName)
+	}
+
+	return resources, edges
+}

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (dao *DAO) ResyncData(event model.SyncEvent, clusterName string) {
+func (dao *DAO) ResyncData(event model.SyncEvent, clusterName string, syncResponse *model.SyncResponse) {
 	klog.Info("Resync full state for cluster ", clusterName)
 
 	// FIXME: REMOVE THIS WORKAROUND. Deleting data for cluster instead of reconcilimg with existing state.
@@ -20,7 +20,7 @@ func (dao *DAO) ResyncData(event model.SyncEvent, clusterName string) {
 	r2, e2 := dao.pool.Exec(context.Background(), "DELETE from search.edges WHERE cluster=$1", clusterName)
 	klog.V(9).Infof("WORKAROUND. Deleting all edges for cluster [%s]. Result: %+v  Errors: %+v", clusterName, r2, e2)
 
-	dao.SyncData(event, clusterName)
+	dao.SyncData(event, clusterName, syncResponse)
 
 	// Get all the existing resources.
 	// r, e := pool.Exec(context.Background(), "SELECT uid FROM search.resources where cluster=$1", clusterName)

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -27,5 +27,5 @@ func Test_ResyncData(t *testing.T) {
 	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
 	// Execute function test.
-	dao.ResyncData(syncEvent, "test-cluster")
+	dao.ResyncData(syncEvent, "test-cluster", nil) // FIXME: Pass SyncResponse.
 }

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -27,5 +27,5 @@ func Test_ResyncData(t *testing.T) {
 	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
 	// Execute function test.
-	dao.ResyncData(syncEvent, "test-cluster", nil) // FIXME: Pass SyncResponse.
+	dao.ResyncData(syncEvent, "test-cluster", &model.SyncResponse{})
 }

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -87,7 +87,7 @@ func (dao *DAO) SyncData(event model.SyncEvent, clusterName string, syncResponse
 	// Wait for all batches to complete.
 	batch.wg.Wait()
 
-	// The response fields below are redundant, adding for compability with existing API.
+	// The response fields below are redundant, these are more interesting for resync.
 	syncResponse.TotalAdded = len(event.AddResources) - len(syncResponse.AddErrors)
 	syncResponse.TotalUpdated = len(event.UpdateResources) - len(syncResponse.UpdateErrors)
 	syncResponse.TotalDeleted = len(event.DeleteResources) - len(syncResponse.DeleteErrors)

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -3,55 +3,38 @@
 package database
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
-	"sync"
 
-	pgx "github.com/jackc/pgx/v4"
 	"github.com/stolostron/search-indexer/pkg/model"
-	"k8s.io/klog/v2"
 )
 
-type batchItem struct {
-	query    string
-	args     []interface{}
-	uid      string // Used to report errors.
-	syncType string // Used to report errors.
-}
-
 func (dao *DAO) SyncData(event model.SyncEvent, clusterName string, syncResponse *model.SyncResponse) {
-	wg := &sync.WaitGroup{}
-	batchItems := make([]batchItem, 0)
 
-	addToBatchQueue := func(syncType string, query string, args ...interface{}) {
-		batchItems = append(batchItems, batchItem{query: query, args: args, uid: args[0].(string), syncType: syncType})
-
-		if len(batchItems) >= dao.batchSize {
-			wg.Add(1)
-			go dao.sendBatch(batchItems, wg, syncResponse) // ??? How do I check for error here?
-			batchItems = make([]batchItem, 0)
-		}
-	}
+	batch := NewBatchWithRetry(dao, syncResponse)
 
 	// ADD RESOURCES
 	for _, resource := range event.AddResources {
-		////// Inserting error
-		// if i == 50 {
-		// 	addToBatchQueue("addResource", "INSERT into search.r values($1,$2,$3)", "id111", 2, 3)
-		// 	addToBatchQueue("updateResource", "INSERT into search.r values($1,$2,$3)", "id222", 2, 3)
-		// 	//  addToBatchQueue("INSERT into search.resources values('a','b','{}')")
-		// 	//  addToBatchQueue("INSERT into search.resources values(1,2,3)")
-		// }
 		data, _ := json.Marshal(resource.Properties)
-		addToBatchQueue("addResource", "INSERT into search.resources values($1,$2,$3)", resource.UID, clusterName, string(data))
+		batch.Queue(batchItem{
+			action: "addResource",
+			query:  "INSERT into search.resources values($1,$2,$3)",
+			uid:    resource.UID,
+			args:   []interface{}{resource.UID, clusterName, string(data)},
+		})
 	}
+
 	// UPDATE RESOURCES
 	// The collector enforces that a resource isn't added and updated in the same sync event.
 	// The uid and cluster fields will never get updated for a resource.
 	for _, resource := range event.UpdateResources {
-		json, _ := json.Marshal(resource.Properties)
-		addToBatchQueue("updateResource", "UPDATE search.resources SET data=$2 WHERE uid=$1", resource.UID, string(json))
+		data, _ := json.Marshal(resource.Properties)
+		batch.Queue(batchItem{
+			action: "updateResource",
+			query:  "UPDATE search.resources SET data=$2 WHERE uid=$1",
+			uid:    resource.UID,
+			args:   []interface{}{resource.UID, string(data)},
+		})
 	}
 
 	// DELETE RESOURCES and all edges pointing to the resource.
@@ -63,15 +46,27 @@ func (dao *DAO) SyncData(event model.SyncEvent, clusterName string, syncResponse
 
 		// TODO: Need better safety for delete errors.
 		// The current retry logic won't work well if there's an error here.
-		addToBatchQueue("deleteResource", "DELETE from search.resources WHERE uid IN ($1)", strings.Join(uids, ", "))
-		addToBatchQueue("deleteResource", "DELETE from search.edges WHERE sourceId IN ($1)", strings.Join(uids, ", "))
-		addToBatchQueue("deleteResource", "DELETE from search.edges WHERE destId IN ($1)", strings.Join(uids, ", "))
+		batch.Queue(batchItem{
+			action: "deleteResource",
+			query:  "DELETE from search.resources WHERE uid IN ($1)",
+			uid:    strings.Join(uids, ", "),
+			args:   []interface{}{strings.Join(uids, ", ")},
+		})
+		batch.Queue(batchItem{
+			action: "deleteResource",
+			query:  "DELETE from search.edges WHERE sourceId IN ($1) OR destId IN ($1)",
+			uid:    strings.Join(uids, ", "),
+			args:   []interface{}{strings.Join(uids, ", ")},
+		})
 	}
 
 	// ADD EDGES
 	for _, edge := range event.AddEdges {
-		addToBatchQueue("addEdge", "INSERT into search.edges values($1,$2,$3,$4,$5,$6)",
-			edge.SourceUID, edge.SourceKind, edge.DestUID, edge.DestKind, edge.EdgeType, clusterName)
+		batch.Queue(batchItem{
+			action: "addEdge",
+			query:  "INSERT into search.edges values($1,$2,$3,$4,$5,$6)",
+			uid:    edge.SourceUID,
+			args:   []interface{}{edge.SourceUID, edge.SourceKind, edge.DestUID, edge.DestKind, edge.EdgeType, clusterName}})
 	}
 
 	// UPDATE EDGES
@@ -79,97 +74,23 @@ func (dao *DAO) SyncData(event model.SyncEvent, clusterName string, syncResponse
 
 	// DELETE EDGES
 	for _, edge := range event.DeleteEdges {
-		addToBatchQueue("deleteEdge", "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3",
-			edge.SourceUID, edge.DestUID, edge.EdgeType)
+		batch.Queue(batchItem{
+			action: "deleteEdge",
+			query:  "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3",
+			uid:    edge.SourceUID,
+			args:   []interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType}})
 	}
 
 	// Flush remaining items in the batch.
-	if len(batchItems) > 0 {
-		wg.Add(1)
-		go dao.sendBatch(batchItems, wg, syncResponse)
-	}
+	batch.flush()
 
 	// Wait for all batches to complete.
-	wg.Wait()
-}
+	batch.wg.Wait()
 
-func (dao *DAO) sendBatch(batchItems []batchItem, wg *sync.WaitGroup, syncResponse *model.SyncResponse) error {
-	defer wg.Done()
-
-	batch := &pgx.Batch{}
-	for _, item := range batchItems {
-		batch.Queue(item.query, item.args...)
-	}
-	br := dao.pool.SendBatch(context.Background(), batch)
-	_, err := br.Exec()
-	br.Close()
-
-	// Process errors.
-	// pgx.Batch is processed as a transaction, so in case of an error, the entire batch will fail.
-	if err != nil {
-		if len(batchItems) == 1 {
-			item := batchItems[0]
-			klog.Errorf("ERROR processing batchItem.  %+v", batchItems[0])
-
-			var errorArray *[]model.SyncError
-			switch item.syncType {
-			case "addResource":
-				errorArray = &syncResponse.AddErrors
-			case "updateResource":
-				errorArray = &syncResponse.UpdateErrors
-			case "deleteResource":
-				errorArray = &syncResponse.DeleteErrors
-			case "addEdge":
-				errorArray = &syncResponse.AddEdgeErrors
-			case "deleteEdge":
-				errorArray = &syncResponse.DeleteEdgeErrors
-			default:
-				klog.Error("Unable to process sync error with type: ", item.syncType)
-			}
-			*errorArray = append(*errorArray, model.SyncError{ResourceUID: batchItems[0].uid, Message: "Error details"})
-
-			return nil // Don't return error here to stop the recursion.
-		}
-
-		klog.Error("Error sending batch, resending smaller batch.")
-
-		// Retry first half.
-		firstHalf := batchItems[:len(batchItems)/2]
-		wg.Add(1)
-		err1 := dao.sendBatch(firstHalf, wg, syncResponse)
-
-		// Retry second half
-		secondHalf := batchItems[len(batchItems)/2:]
-		wg.Add(1)
-		err2 := dao.sendBatch(secondHalf, wg, syncResponse)
-
-		// Returns error only if we fail processing either retry.
-		if err1 != nil && err2 != nil {
-			return nil
-		}
-	}
-	return err
-}
-
-// TODO: move this to different file.
-func (dao *DAO) ClusterTotals(clusterName string) (resources int, edges int) {
-	batch := &pgx.Batch{}
-	batch.Queue("SELECT count(*) FROM search.resources WHERE cluster=$1", clusterName)
-	batch.Queue("SELECT count(*) FROM search.edges WHERE cluster=$1", clusterName)
-
-	br := dao.pool.SendBatch(context.Background(), batch)
-	defer br.Close()
-
-	resourcesRow := br.QueryRow()
-	resourcesErr := resourcesRow.Scan(&resources)
-	if resourcesErr != nil {
-		klog.Error("Error reading total resources for cluster ", clusterName)
-	}
-	edgesRow := br.QueryRow()
-	edgesErr := edgesRow.Scan(&edges)
-	if edgesErr != nil {
-		klog.Error("Error reading total edges for cluster ", clusterName)
-	}
-
-	return resources, edges
+	// The response fields below are redundant, adding for compability with existing API.
+	syncResponse.TotalAdded = len(event.AddResources) - len(syncResponse.AddErrors)
+	syncResponse.TotalUpdated = len(event.UpdateResources) - len(syncResponse.UpdateErrors)
+	syncResponse.TotalDeleted = len(event.DeleteResources) - len(syncResponse.DeleteErrors)
+	syncResponse.TotalEdgesAdded = len(event.AddEdges) - len(syncResponse.AddEdgeErrors)
+	syncResponse.TotalEdgesDeleted = len(event.DeleteEdges) - len(syncResponse.DeleteEdgeErrors)
 }

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -13,79 +13,163 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (dao *DAO) SyncData(event model.SyncEvent, clusterName string) {
-	wg := &sync.WaitGroup{}
-	batch := &pgx.Batch{}
-	count := 0
+type batchItem struct {
+	query    string
+	args     []interface{}
+	uid      string // Used to report errors.
+	syncType string // Used to report errors.
+}
 
-	// ADD
-	for _, resource := range event.AddResources {
-		data, _ := json.Marshal(resource.Properties)
-		batch.Queue("INSERT into search.resources values($1,$2,$3)", resource.UID, clusterName, string(data))
-		count++
-		if count == dao.batchSize {
+func (dao *DAO) SyncData(event model.SyncEvent, clusterName string, syncResponse *model.SyncResponse) {
+	wg := &sync.WaitGroup{}
+	batchItems := make([]batchItem, 0)
+
+	addToBatchQueue := func(syncType string, query string, args ...interface{}) {
+		batchItems = append(batchItems, batchItem{query: query, args: args, uid: args[0].(string), syncType: syncType})
+
+		if len(batchItems) >= dao.batchSize {
 			wg.Add(1)
-			go dao.sendBatch(*batch, wg)
-			count = 0
-			batch = &pgx.Batch{}
+			go dao.sendBatch(batchItems, wg, syncResponse) // ??? How do I check for error here?
+			batchItems = make([]batchItem, 0)
 		}
 	}
-	// UPDATE
+
+	// ADD RESOURCES
+	for _, resource := range event.AddResources {
+		////// Inserting error
+		// if i == 50 {
+		// 	addToBatchQueue("addResource", "INSERT into search.r values($1,$2,$3)", "id111", 2, 3)
+		// 	addToBatchQueue("updateResource", "INSERT into search.r values($1,$2,$3)", "id222", 2, 3)
+		// 	//  addToBatchQueue("INSERT into search.resources values('a','b','{}')")
+		// 	//  addToBatchQueue("INSERT into search.resources values(1,2,3)")
+		// }
+		data, _ := json.Marshal(resource.Properties)
+		addToBatchQueue("addResource", "INSERT into search.resources values($1,$2,$3)", resource.UID, clusterName, string(data))
+	}
+	// UPDATE RESOURCES
+	// The collector enforces that a resource isn't added and updated in the same sync event.
+	// The uid and cluster fields will never get updated for a resource.
 	for _, resource := range event.UpdateResources {
 		json, _ := json.Marshal(resource.Properties)
-		batch.Queue("UPDATE search.resources SET data=$2 WHERE uid=$1", resource.UID, string(json))
-		count++
-		if count == dao.batchSize {
-			wg.Add(1)
-			go dao.sendBatch(*batch, wg)
-			count = 0
-			batch = &pgx.Batch{}
-		}
+		addToBatchQueue("updateResource", "UPDATE search.resources SET data=$2 WHERE uid=$1", resource.UID, string(json))
 	}
 
-	// ADD EDGES
-	for _, edge := range event.AddEdges {
-		batch.Queue("INSERT into search.edges values($1,$2,$3,$4,$5,$6)", edge.SourceUID, edge.SourceKind, edge.DestUID, edge.DestKind, edge.EdgeType, clusterName)
-		count++
-		if count == dao.batchSize {
-			wg.Add(1)
-			go dao.sendBatch(*batch, wg)
-			count = 0
-			batch = &pgx.Batch{}
-		}
-	}
-
-	// UPDATE EDGES
-	// We don't need update. The collector only sends add and delete for edges.
-
-	// DELETE - NODE AND EDGES
+	// DELETE RESOURCES and all edges pointing to the resource.
 	if len(event.DeleteResources) > 0 {
 		uids := make([]string, len(event.DeleteResources))
 		for i, resource := range event.DeleteResources {
 			uids[i] = resource.UID
 		}
-		batch.Queue("DELETE from search.resources WHERE uid IN ($1)", strings.Join(uids, ", "))
-		batch.Queue("DELETE from search.edges WHERE sourceId IN ($1)", strings.Join(uids, ", "))
-		batch.Queue("DELETE from search.edges WHERE destId IN ($1)", strings.Join(uids, ", "))
-		count += 3
+
+		// TODO: Need better safety for delete errors.
+		// The current retry logic won't work well if there's an error here.
+		addToBatchQueue("deleteResource", "DELETE from search.resources WHERE uid IN ($1)", strings.Join(uids, ", "))
+		addToBatchQueue("deleteResource", "DELETE from search.edges WHERE sourceId IN ($1)", strings.Join(uids, ", "))
+		addToBatchQueue("deleteResource", "DELETE from search.edges WHERE destId IN ($1)", strings.Join(uids, ", "))
 	}
-	if count > 0 {
+
+	// ADD EDGES
+	for _, edge := range event.AddEdges {
+		addToBatchQueue("addEdge", "INSERT into search.edges values($1,$2,$3,$4,$5,$6)",
+			edge.SourceUID, edge.SourceKind, edge.DestUID, edge.DestKind, edge.EdgeType, clusterName)
+	}
+
+	// UPDATE EDGES
+	// Edges are never updated. The collector only sends ADD and DELETE eveents for edges.
+
+	// DELETE EDGES
+	for _, edge := range event.DeleteEdges {
+		addToBatchQueue("deleteEdge", "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3",
+			edge.SourceUID, edge.DestUID, edge.EdgeType)
+	}
+
+	// Flush remaining items in the batch.
+	if len(batchItems) > 0 {
 		wg.Add(1)
-		go dao.sendBatch(*batch, wg)
+		go dao.sendBatch(batchItems, wg, syncResponse)
 	}
 
+	// Wait for all batches to complete.
 	wg.Wait()
-
 }
 
-func (dao *DAO) sendBatch(batch pgx.Batch, wg *sync.WaitGroup) {
+func (dao *DAO) sendBatch(batchItems []batchItem, wg *sync.WaitGroup, syncResponse *model.SyncResponse) error {
 	defer wg.Done()
-	br := dao.pool.SendBatch(context.Background(), &batch)
-	defer br.Close()
-	_, err := br.Exec()
-	if err != nil {
-		klog.Error("Error sending batch.", err)
 
-		// TODO: Need to report the errors back in response body.
+	batch := &pgx.Batch{}
+	for _, item := range batchItems {
+		batch.Queue(item.query, item.args...)
 	}
+	br := dao.pool.SendBatch(context.Background(), batch)
+	_, err := br.Exec()
+	br.Close()
+
+	// Process errors.
+	// pgx.Batch is processed as a transaction, so in case of an error, the entire batch will fail.
+	if err != nil {
+		if len(batchItems) == 1 {
+			item := batchItems[0]
+			klog.Errorf("ERROR processing batchItem.  %+v", batchItems[0])
+
+			var errorArray *[]model.SyncError
+			switch item.syncType {
+			case "addResource":
+				errorArray = &syncResponse.AddErrors
+			case "updateResource":
+				errorArray = &syncResponse.UpdateErrors
+			case "deleteResource":
+				errorArray = &syncResponse.DeleteErrors
+			case "addEdge":
+				errorArray = &syncResponse.AddEdgeErrors
+			case "deleteEdge":
+				errorArray = &syncResponse.DeleteEdgeErrors
+			default:
+				klog.Error("Unable to process sync error with type: ", item.syncType)
+			}
+			*errorArray = append(*errorArray, model.SyncError{ResourceUID: batchItems[0].uid, Message: "Error details"})
+
+			return nil // Don't return error here to stop the recursion.
+		}
+
+		klog.Error("Error sending batch, resending smaller batch.")
+
+		// Retry first half.
+		firstHalf := batchItems[:len(batchItems)/2]
+		wg.Add(1)
+		err1 := dao.sendBatch(firstHalf, wg, syncResponse)
+
+		// Retry second half
+		secondHalf := batchItems[len(batchItems)/2:]
+		wg.Add(1)
+		err2 := dao.sendBatch(secondHalf, wg, syncResponse)
+
+		// Returns error only if we fail processing either retry.
+		if err1 != nil && err2 != nil {
+			return nil
+		}
+	}
+	return err
+}
+
+// TODO: move this to different file.
+func (dao *DAO) ClusterTotals(clusterName string) (resources int, edges int) {
+	batch := &pgx.Batch{}
+	batch.Queue("SELECT count(*) FROM search.resources WHERE cluster=$1", clusterName)
+	batch.Queue("SELECT count(*) FROM search.edges WHERE cluster=$1", clusterName)
+
+	br := dao.pool.SendBatch(context.Background(), batch)
+	defer br.Close()
+
+	resourcesRow := br.QueryRow()
+	resourcesErr := resourcesRow.Scan(&resources)
+	if resourcesErr != nil {
+		klog.Error("Error reading total resources for cluster ", clusterName)
+	}
+	edgesRow := br.QueryRow()
+	edgesErr := edgesRow.Scan(&edges)
+	if edgesErr != nil {
+		klog.Error("Error reading total edges for cluster ", clusterName)
+	}
+
+	return resources, edges
 }

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -17,7 +17,7 @@ func Test_SyncData(t *testing.T) {
 
 	// Mock PosgreSQL calls
 	br := BatchResults{}
-	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(4)
+	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(5)
 
 	// Prepare Request data
 	data, _ := os.Open("./mocks/simple.json")
@@ -25,5 +25,5 @@ func Test_SyncData(t *testing.T) {
 	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
 	// Execute test
-	dao.SyncData(syncEvent, "test-cluster", nil) // FIXME: Pass SyncResponse.
+	dao.SyncData(syncEvent, "test-cluster", &model.SyncResponse{})
 }

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -25,5 +25,5 @@ func Test_SyncData(t *testing.T) {
 	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
 	// Execute test
-	dao.SyncData(syncEvent, "test-cluster")
+	dao.SyncData(syncEvent, "test-cluster", nil) // FIXME: Pass SyncResponse.
 }

--- a/pkg/server/syncHandler.go
+++ b/pkg/server/syncHandler.go
@@ -52,16 +52,14 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 	syncResponse.TotalResources = totalResources
 	syncResponse.TotalEdges = totalEdges
 
-	
 	// Send Response
 	encodeError := json.NewEncoder(w).Encode(syncResponse)
 	if encodeError == nil {
 		w.WriteHeader(http.StatusOK)
-	} else
+	} else {
 		klog.Error("Error responding to SyncEvent:", encodeError, syncResponse)
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-
 
 	// Log request and metrics.
 	klog.V(5).Infof("Request from [%s] took [%v] clearAll [%t] addTotal [%d]", clusterName, time.Since(start), syncEvent.ClearAll, len(syncEvent.AddResources))

--- a/pkg/server/syncHandler.go
+++ b/pkg/server/syncHandler.go
@@ -52,14 +52,20 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 	syncResponse.TotalResources = totalResources
 	syncResponse.TotalEdges = totalEdges
 
-	w.WriteHeader(http.StatusOK)
+	
+	// Send Response
 	encodeError := json.NewEncoder(w).Encode(syncResponse)
-	if encodeError != nil {
+	if encodeError == nil {
+		w.WriteHeader(http.StatusOK)
+	} else
 		klog.Error("Error responding to SyncEvent:", encodeError, syncResponse)
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 
-	// klog.V(5).Infof("SyncResponse: %+v", syncResponse)
+
+	// Log request and metrics.
 	klog.V(5).Infof("Request from [%s] took [%v] clearAll [%t] addTotal [%d]", clusterName, time.Since(start), syncEvent.ClearAll, len(syncEvent.AddResources))
+	// klog.V(5).Infof("Response for [%s]: %+v", clusterName, syncResponse)
 
 	// Record metrics.
 	OpsProcessed.WithLabelValues(clusterName, r.RequestURI).Inc()

--- a/pkg/server/syncHandler_test.go
+++ b/pkg/server/syncHandler_test.go
@@ -29,14 +29,15 @@ func Test_syncRequest(t *testing.T) {
 
 	// Create server with mock database.
 	server, mockPool := buildMockServer(t)
-	br := BatchResults{}
-	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br)
+	br_index := 0
+	br := BatchResults{rows: []int{5, 3}, index: &br_index}
+	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(2)
 
 	router.HandleFunc("/aggregator/clusters/{id}/sync", server.SyncResources)
 	router.ServeHTTP(responseRecorder, request)
 
 	// Validation
-	expected := model.SyncResponse{Version: config.COMPONENT_VERSION}
+	expected := model.SyncResponse{Version: config.COMPONENT_VERSION, TotalAdded: 2, TotalResources: 5, TotalEdges: 3}
 
 	if responseRecorder.Code != http.StatusOK {
 		t.Errorf("Want status '%d', got '%d'", http.StatusOK, responseRecorder.Code)
@@ -66,14 +67,15 @@ func Test_resyncRequest(t *testing.T) {
 
 	// Create server with mock database.
 	server, mockPool := buildMockServer(t)
-	br := BatchResults{}
+	br_index := 0
+	br := BatchResults{rows: []int{10, 4}, index: &br_index}
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
-	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br)
+	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(2)
 
 	router.HandleFunc("/aggregator/clusters/{id}/sync", server.SyncResources)
 	router.ServeHTTP(responseRecorder, request)
 
-	expected := model.SyncResponse{Version: config.COMPONENT_VERSION}
+	expected := model.SyncResponse{Version: config.COMPONENT_VERSION, TotalAdded: 2, TotalResources: 10, TotalEdges: 4}
 
 	if responseRecorder.Code != http.StatusOK {
 		t.Errorf("Want status '%d', got '%d'", http.StatusOK, responseRecorder.Code)

--- a/pkg/server/syncHandler_test.go
+++ b/pkg/server/syncHandler_test.go
@@ -29,8 +29,8 @@ func Test_syncRequest(t *testing.T) {
 
 	// Create server with mock database.
 	server, mockPool := buildMockServer(t)
-	br_index := 0
-	br := BatchResults{rows: []int{5, 3}, index: &br_index}
+
+	br := &batchResults{rows: []int{5, 3}}
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(2)
 
 	router.HandleFunc("/aggregator/clusters/{id}/sync", server.SyncResources)
@@ -67,8 +67,8 @@ func Test_resyncRequest(t *testing.T) {
 
 	// Create server with mock database.
 	server, mockPool := buildMockServer(t)
-	br_index := 0
-	br := BatchResults{rows: []int{10, 4}, index: &br_index}
+
+	br := &batchResults{rows: []int{10, 4}}
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(2)
 

--- a/pkg/server/testHelper_test.go
+++ b/pkg/server/testHelper_test.go
@@ -11,21 +11,43 @@ import (
 	"github.com/stolostron/search-indexer/pkg/database"
 )
 
-type BatchResults struct{}
+// ====================================================
+// Mock the Row interface defined in the pgx library.
+// https://github.com/jackc/pgx/blob/master/rows.go#L24
+// ====================================================
+type Row struct {
+	mockValue int
+}
 
-func (s BatchResults) Exec() (pgconn.CommandTag, error) {
-	return nil, nil
-}
-func (s BatchResults) Query() (pgx.Rows, error) {
-	return nil, nil
-}
-func (s BatchResults) QueryRow() pgx.Row {
+func (r *Row) Scan(dest ...interface{}) error {
+	*dest[0].(*int) = r.mockValue
 	return nil
 }
-func (s BatchResults) QueryFunc(scans []interface{}, f func(pgx.QueryFuncRow) error) (pgconn.CommandTag, error) {
+
+// ===========================================================
+// Mock the BatchResults interface defined in the pgx library.
+// https://github.com/jackc/pgx/blob/master/batch.go#L34
+// ===========================================================
+type BatchResults struct {
+	rows  []int
+	index *int
+}
+
+func (br BatchResults) Exec() (pgconn.CommandTag, error) {
 	return nil, nil
 }
-func (s BatchResults) Close() error {
+func (br BatchResults) Query() (pgx.Rows, error) {
+	return nil, nil
+}
+func (br BatchResults) QueryRow() pgx.Row {
+	row := &Row{mockValue: br.rows[*br.index]}
+	*br.index = *br.index + 1
+	return row
+}
+func (br BatchResults) QueryFunc(scans []interface{}, f func(pgx.QueryFuncRow) error) (pgconn.CommandTag, error) {
+	return nil, nil
+}
+func (br BatchResults) Close() error {
 	return nil
 }
 

--- a/pkg/server/testHelper_test.go
+++ b/pkg/server/testHelper_test.go
@@ -28,26 +28,26 @@ func (r *Row) Scan(dest ...interface{}) error {
 // Mock the BatchResults interface defined in the pgx library.
 // https://github.com/jackc/pgx/blob/master/batch.go#L34
 // ===========================================================
-type BatchResults struct {
+type batchResults struct {
 	rows  []int
-	index *int
+	index int
 }
 
-func (br BatchResults) Exec() (pgconn.CommandTag, error) {
+func (br *batchResults) Exec() (pgconn.CommandTag, error) {
 	return nil, nil
 }
-func (br BatchResults) Query() (pgx.Rows, error) {
+func (br *batchResults) Query() (pgx.Rows, error) {
 	return nil, nil
 }
-func (br BatchResults) QueryRow() pgx.Row {
-	row := &Row{mockValue: br.rows[*br.index]}
-	*br.index = *br.index + 1
+func (br *batchResults) QueryRow() pgx.Row {
+	row := &Row{mockValue: br.rows[br.index]}
+	br.index = br.index + 1
 	return row
 }
-func (br BatchResults) QueryFunc(scans []interface{}, f func(pgx.QueryFuncRow) error) (pgconn.CommandTag, error) {
+func (br *batchResults) QueryFunc(scans []interface{}, f func(pgx.QueryFuncRow) error) (pgconn.CommandTag, error) {
 	return nil, nil
 }
-func (br BatchResults) Close() error {
+func (br *batchResults) Close() error {
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/17972

### Changes
- SyncResponse includes total resources and edges.
- SyncResponse includes errors when applicable.