### PR TITLE
Locust test discover route to current target cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test-send: ## Sends a simulated request for testing using cURL.
 N_CLUSTERS ?=2
 HOST ?= $(shell oc get route search-indexer -o custom-columns=host:.spec.host --no-headers -n open-cluster-management --ignore-not-found=true)
 ifeq ($(strip $(HOST)),)
-	CONFIGURATION_MSG = @echo \\n\\tThe search-api route was not found in the target cluster.\\n\
+	CONFIGURATION_MSG = @echo \\n\\tThe search-indexer route was not found in the target cluster.\\n\
 	\\tThis test will run against the local instance https://localhost:3010\\n\
 	\\tIf you want to run this test against a cluster, create the route with make test-scale-setup\\n;
 	

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,26 @@ test-send: ## Sends a simulated request for testing using cURL.
 	curl -k -d "@pkg/server/mocks/clusterA.json" -X POST https://localhost:3010/aggregator/clusters/clusterA/sync
 
 N_CLUSTERS ?=2
-test-scale: check-locust ## Sends multiple simulated requests for testing using Locust. Use N_CLUSTERS to change the number of simulated clusters.
-	cd test; locust --headless --users ${N_CLUSTERS} --spawn-rate ${N_CLUSTERS} -H https://localhost:3010 -f locust-clusters.py
+HOST ?= $(shell oc get route search-indexer -o custom-columns=host:.spec.host --no-headers -n open-cluster-management --ignore-not-found=true)
+ifeq ($(strip $(HOST)),)
+	CONFIGURATION_MSG = @echo \\n\\tThe search-api route was not found in the target cluster.\\n\
+	\\tThis test will run against the local instance https://localhost:3010\\n\
+	\\tIf you want to run this test against a cluster, create the route with make test-scale-setup\\n;
+	
+	HOST = localhost:3010
+endif
 
-test-scale-ui: check-locust ## Start Locust and opens the UI to drive scale tests.
+test-scale: check-locust ## Simulate multiple clusters posting data to the indexer. Use N_Clusters to change the number of simulated clusters.
+	${CONFIGURATION_MSG}
+	cd test; locust --headless --users ${N_CLUSTERS} --spawn-rate ${N_CLUSTERS} -H https://${HOST} -f locust-clusters.py
+
+test-scale-ui: check-locust ## Start Locust and open the web browser to drive scale tests.
+	${CONFIGURATION_MSG}
 	open http://0.0.0.0:8089/
-	cd test; locust --users ${N_CLUSTERS} --spawn-rate ${N_CLUSTERS} -H https://localhost:3010 -f locust-clusters.py
+	cd test; locust --users ${N_CLUSTERS} --spawn-rate ${N_CLUSTERS} -H https://${HOST} -f locust-clusters.py
+
+test-scale-setup: ## Creates the search-indexer route in the current target cluster.
+	oc create route passthrough search-indexer --service=search-indexer -n open-cluster-management
 
 check-locust: ## Checks if Locust is installed in the system.
 ifeq (,$(shell which locust))


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  stolostron/backlog#19286

### Description of changes
- Update makefile to automatically discover the search-indexer route on the current target cluster when running Locust.
- Matches the Makefile for search-v2-api.
