### PR TITLE
fix sonar project key - rename to open-cluster-management

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 ###############################################################################
 # Copyright Contributors to the Open Cluster Management project
 ###############################################################################
-sonar.projectKey=stolostron_search-indexer
+sonar.projectKey=open-cluster-management_search-indexer
 sonar.projectName=search-indexer
 sonar.sources=.
 sonar.exclusions=**/*_test.go,**/vendor/**,**/vbh/**,test/**,main.go


### PR DESCRIPTION
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>

**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>

### Description of changes
Project key on sonar is open-cluster-management.
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/32376120/179003843-2602ab8e-2e8f-43eb-9355-f34ae5782a96.png">

sonar-presubmit-job will fail because of the mismatch.
See slack discussion: https://coreos.slack.com/archives/CSZLMKPS5/p1657768166877289