### PR TITLE
Ignore the cluster pseudo-node when validating resources

### DIFF
--- a/pkg/database/dataValidation.go
+++ b/pkg/database/dataValidation.go
@@ -20,7 +20,7 @@ func (dao *DAO) ClusterTotals(clusterName string) (resources int, edges int) {
 		Select(goqu.COUNT("*")).
 		Where(
 			goqu.C("cluster").Eq(clusterName),
-			goqu.C("uid").Neq(string("cluster__"+clusterName))). // Ignore the cluster pseudonode, not a kube resource.
+			goqu.C("uid").Neq(string("cluster__"+clusterName))). // Ignore cluster pseudo-node, not a kube resource.
 		ToSQL()
 
 	checkError(err, fmt.Sprintf("Error creating query to count resources in cluster %s:%s ",

--- a/pkg/database/dataValidation.go
+++ b/pkg/database/dataValidation.go
@@ -18,7 +18,10 @@ func (dao *DAO) ClusterTotals(clusterName string) (resources int, edges int) {
 	// Sample query: SELECT count(*) FROM search.resources WHERE cluster=$1
 	resourceCountSql, params, err := goqu.From(goqu.S("search").Table("resources")).
 		Select(goqu.COUNT("*")).
-		Where(goqu.C("cluster").Eq(clusterName)).ToSQL()
+		Where(
+			goqu.C("cluster").Eq(clusterName),
+			goqu.C("uid").Neq(string("cluster__"+clusterName))). // Ignore the cluster pseudonode, not a kube resource.
+		ToSQL()
 
 	checkError(err, fmt.Sprintf("Error creating query to count resources in cluster %s:%s ",
 		clusterName, err))

--- a/pkg/database/dataValidation_test.go
+++ b/pkg/database/dataValidation_test.go
@@ -21,7 +21,7 @@ func Test_ClusterTotals(t *testing.T) {
 		},
 	}
 	// mock queries
-	batch.Queue(`SELECT COUNT(*) FROM "search"."resources" WHERE ("cluster" = 'cluster_foo')`, []interface{}{}...)
+	batch.Queue(`SELECT COUNT(*) FROM "search"."resources" WHERE (("cluster" = 'cluster_foo') AND ("uid" != 'cluster__cluster_foo'))`, []interface{}{}...)
 	batch.Queue(`SELECT COUNT(*) FROM "search"."edges" WHERE (("cluster" = 'cluster_foo') AND ("edgetype" != 'interCluster'))`, []interface{}{}...)
 
 	mockPool.EXPECT().SendBatch(context.Background(), batch).Return(br)


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/27063

### Description of changes
The previous PR #73 added the cluster column to the cluster pseudo-node, this affected the validation logic. With this change we'll ignore this node in the resource counts.
