### PR TITLE
Track enabled addons for disabled cluster message

### DIFF
--- a/pkg/clustersync/clusterSync_test.go
+++ b/pkg/clustersync/clusterSync_test.go
@@ -85,6 +85,7 @@ func initializeVars() {
 		"label":               labelMap,
 		"apigroup":            managedClusterInfoApiGrp,
 		"kind_plural":         "managedclusterinfos",
+		"addon":               map[string]string{"application-manager": "false", "cert-policy-controller": "false", "cluster-proxy": "false", "config-policy-controller": "false", "governance-policy-framework": "false", "iam-policy-controller": "false", "observability-controller": "false", "search-collector": "false", "work-manager": "false"},
 		"cpu":                 0,
 		"created":             "0001-01-01T00:00:00Z",
 		"kind":                "Cluster",

--- a/pkg/clustersync/clusterSync_test.go
+++ b/pkg/clustersync/clusterSync_test.go
@@ -63,8 +63,6 @@ func fakeDynamicClient() *fake.FakeDynamicClient {
 }
 
 func newTestUnstructured(apiVersion, kind, namespace, name, uid string) *unstructured.Unstructured {
-	labels := make(map[string]interface{})
-	labels["env"] = "dev"
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": apiVersion,
@@ -73,19 +71,34 @@ func newTestUnstructured(apiVersion, kind, namespace, name, uid string) *unstruc
 				"namespace": namespace,
 				"name":      name,
 				"uid":       uid,
-				"labels":    labels,
+				"labels": map[string]interface{}{
+					"env": "dev",
+					"feature.open-cluster-management.io/addon-search-collector": "available",
+				},
 			},
 		},
 	}
 }
 
 func initializeVars() {
-	labelMap := map[string]string{"env": "dev"}
 	clusterProps := map[string]interface{}{
-		"label":               labelMap,
+		"label": map[string]string{
+			"env": "dev",
+			"feature.open-cluster-management.io/addon-search-collector": "available",
+		},
+		"addon": map[string]string{
+			"application-manager":         "false",
+			"cert-policy-controller":      "false",
+			"cluster-proxy":               "false",
+			"config-policy-controller":    "false",
+			"governance-policy-framework": "false",
+			"iam-policy-controller":       "false",
+			"observability-controller":    "false",
+			"search-collector":            "true",
+			"work-manager":                "false",
+		},
 		"apigroup":            managedClusterInfoApiGrp,
 		"kind_plural":         "managedclusterinfos",
-		"addon":               map[string]string{"application-manager": "false", "cert-policy-controller": "false", "cluster-proxy": "false", "config-policy-controller": "false", "governance-policy-framework": "false", "iam-policy-controller": "false", "observability-controller": "false", "search-collector": "false", "work-manager": "false"},
 		"cpu":                 0,
 		"created":             "0001-01-01T00:00:00Z",
 		"kind":                "Cluster",


### PR DESCRIPTION
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>

**Related Issue:**  https://issues.redhat.com/browse/ACM-2671

### Description of changes
- Add property `adddon` to Cluster pseudo-node. It tracks the enabled addons.
