### PR TITLE
ACM-3065 Fixes lock problem in requestLimiter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ var Cfg = new()
 type Config struct {
 	DBBatchSize    int // Batch size used to write to DB.
 	DBHost         string
-	DBMaxConns     int // Max size of DB connection pool. Default: 30
+	DBMaxConns     int // Max size of DB connection pool. Default: 20
 	DBPort         int
 	DBName         string
 	DBUser         string
@@ -49,7 +49,7 @@ func new() *Config {
 		DevelopmentMode: DEVELOPMENT_MODE, // Do not read this from ENV. See config_development.go to enable.
 		DBBatchSize:     getEnvAsInt("DB_BATCH_SIZE", 500),
 		DBHost:          getEnv("DB_HOST", "localhost"),
-		DBMaxConns:      getEnvAsInt("DB_MAX_CONNS", int(20)), // Postgres has 100 conns. This allows scaling the indexer.
+		DBMaxConns:      getEnvAsInt("DB_MAX_CONNS", int(20)), // Postgres has 100 conns. 20 allows scaling indexer
 		DBPort:          getEnvAsInt("DB_PORT", 5432),
 		DBName:          getEnv("DB_NAME", ""),
 		DBUser:          getEnv("DB_USER", ""),
@@ -65,7 +65,7 @@ func new() *Config {
 		MaxBackoffMS: getEnvAsInt("MAX_BACKOFF_MS", 300000), // 5 min
 		// EdgeBuildRateMS:       getEnvAsInt("EDGE_BUILD_RATE_MS", 15000), // 15 sec
 		RediscoverRateMS: getEnvAsInt("REDISCOVER_RATE_MS", 300000), // 5 min
-		RequestLimit:     getEnvAsInt("REQUEST_LIMIT", 50), // Limit to 50 to keep memory below 1GB.
+		RequestLimit:     getEnvAsInt("REQUEST_LIMIT", 50),          // Limit to 50 to keep memory below 1GB.
 		// SkipClusterValidation: getEnvAsBool("SKIP_CLUSTER_VALIDATION", false),
 	}
 


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://issues.redhat.com/browse/ACM-3065

### Description of changes

Fixes the following error introduced by the previous PR.
```
goroutine 283 [running]:
runtime.throw({0x19770b7?, 0x20?})
runtime/panic.go:992 +0x71 fp=0xc00172f7e0 sp=0xc00172f7b0 pc=0x437111
runtime.mapaccess2_faststr(0x6?, 0x7f00ff9909f0?, {0xc0007b19fa, 0x8})
runtime/map_faststr.go:117 +0x3d4 fp=0xc00172f848 sp=0xc00172f7e0 pc=0x412ff4
github.com/stolostron/search-indexer/pkg/server.requestLimiterMiddleware.func1({0x1bb1f60, 0xc000773dc0}, 0xc0008eee40?)
github.com/stolostron/search-indexer/pkg/server/requestLimiter.go:28 +0x197 fp=0xc00172f948 sp=0xc00172f848 pc=0x159fff7
net/http.HandlerFunc.ServeHTTP(0xc000daf600?, {0x1bb1f60?, 0xc000773dc0?}, 0x793bf4?)
```
