### PR TITLE
ACM-3265 Add index to resolve CPU issues

### DIFF
--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -128,6 +128,18 @@ func (dao *DAO) InitializeTables(ctx context.Context) {
 		"CREATE INDEX IF NOT EXISTS data_hubCluster_idx ON search.resources USING GIN "+
 			"((data ->  '_hubClusterResource')) WHERE data ? '_hubClusterResource'")
 	checkError(err, "Error creating index on search.resources data key _hubClusterResource.")
+
+	_, err = dao.pool.Exec(ctx,
+		"CREATE INDEX IF NOT EXISTS edges_sourceid_idx ON search.edges USING btree (sourceid)")
+	checkError(err, "Error creating index on search.edges key sourceid.")
+
+	_, err = dao.pool.Exec(ctx,
+		"CREATE INDEX IF NOT EXISTS edges_destid_idx ON search.edges USING btree (destid)")
+	checkError(err, "Error creating index on search.edges key destid.")
+
+	_, err = dao.pool.Exec(ctx,
+		"CREATE INDEX IF NOT EXISTS edges_cluster_idx ON search.edges USING btree (cluster)")
+	checkError(err, "Error creating index on search.edges key cluster.")
 }
 
 func checkError(err error, logMessage string) {

--- a/pkg/database/connection_test.go
+++ b/pkg/database/connection_test.go
@@ -23,7 +23,6 @@ func Test_initializeTables(t *testing.T) {
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS data_cluster_idx ON search.resources USING btree (cluster)")).Return(nil, nil)
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS data_composite_idx ON search.resources USING GIN ((data -> '_hubClusterResource'::text), (data -> 'namespace'::text), (data -> 'apigroup'::text), (data -> 'kind_plural'::text))")).Return(nil, nil)
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS data_hubCluster_idx ON search.resources USING GIN ((data ->  '_hubClusterResource')) WHERE data ? '_hubClusterResource'")).Return(nil, nil)
-
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS edges_sourceid_idx ON search.edges USING btree (sourceid)")).Return(nil, nil)
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS edges_destid_idx ON search.edges USING btree (destid)")).Return(nil, nil)
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS edges_cluster_idx ON search.edges USING btree (cluster)")).Return(nil, nil)

--- a/pkg/database/connection_test.go
+++ b/pkg/database/connection_test.go
@@ -23,6 +23,11 @@ func Test_initializeTables(t *testing.T) {
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS data_cluster_idx ON search.resources USING btree (cluster)")).Return(nil, nil)
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS data_composite_idx ON search.resources USING GIN ((data -> '_hubClusterResource'::text), (data -> 'namespace'::text), (data -> 'apigroup'::text), (data -> 'kind_plural'::text))")).Return(nil, nil)
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS data_hubCluster_idx ON search.resources USING GIN ((data ->  '_hubClusterResource')) WHERE data ? '_hubClusterResource'")).Return(nil, nil)
+
+	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS edges_sourceid_idx ON search.edges USING btree (sourceid)")).Return(nil, nil)
+	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS edges_destid_idx ON search.edges USING btree (destid)")).Return(nil, nil)
+	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq("CREATE INDEX IF NOT EXISTS edges_cluster_idx ON search.edges USING btree (cluster)")).Return(nil, nil)
+
 	// Execute function test.
 	dao.InitializeTables(context.Background())
 


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://issues.redhat.com/browse/ACM-3265

### Description of changes
- Add a new index on search.edges for the cluster key. This index greatly improves efficiency of the sync validation logic.
- Add missing index for search.edges. These were created only from the operator.
