### PR TITLE
ACM-5168: Propagate context from incoming requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ run: ## Run the service locally.
 .PHONY: lint
 lint: ## Run lint and gosec tool.
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.47.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.52.2
 	CGO_ENABLED=0 GOGC=25 golangci-lint run --timeout=3m
 	go mod tidy
 	gosec ./...

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -9,7 +9,7 @@ build:
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.47.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.52.2
 	CGO_ENABLED=0 GOGC=25 golangci-lint run --timeout=3m
 	gosec ./...
 

--- a/pkg/database/batch.go
+++ b/pkg/database/batch.go
@@ -99,7 +99,7 @@ func (b *batchWithRetry) sendBatch(items []batchItem) error {
 		return nil // We have processed the error, so don't return an error here to stop the recursion.
 
 	} else if execErr != nil {
-		// Error in sentdbatch, resend queries using smaller batches.
+		// Error in send batch, resend queries using smaller batches.
 		// Use a binary search recursively until we find the error.
 
 		b.wg.Add(2)

--- a/pkg/database/connection_test.go
+++ b/pkg/database/connection_test.go
@@ -42,7 +42,7 @@ func Test_checkErrorAndRollback(t *testing.T) {
 	e := errors.New("table resources not found")
 	logMessage := "Error commiting delete cluster transaction for cluster: cluster_foo"
 	// Execute function test.
-	checkErrorAndRollback(e, logMessage, mockConn, context.TODO())
+	checkErrorAndRollback(e, logMessage, mockConn, context.Background())
 
 }
 func Test_checkErrorAndRollbackError(t *testing.T) {
@@ -56,6 +56,6 @@ func Test_checkErrorAndRollbackError(t *testing.T) {
 	mockConn.ExpectRollback().WillReturnError(e) // Rollback returns error
 	logMessage := "Error commiting delete cluster transaction for cluster: cluster_foo"
 	// Execute function test.
-	checkErrorAndRollback(e, logMessage, mockConn, context.TODO())
+	checkErrorAndRollback(e, logMessage, mockConn, context.Background())
 
 }

--- a/pkg/database/dataValidation.go
+++ b/pkg/database/dataValidation.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Query resource and edge count for a cluster. Used for data validation.
-func (dao *DAO) ClusterTotals(clusterName string) (resources int, edges int) {
+func (dao *DAO) ClusterTotals(ctx context.Context, clusterName string) (resources int, edges int) {
 	batch := &pgx.Batch{}
 
 	// Sample query: SELECT count(*) FROM search.resources WHERE cluster=$1
@@ -40,7 +40,7 @@ func (dao *DAO) ClusterTotals(clusterName string) (resources int, edges int) {
 		clusterName, err))
 	batch.Queue(edgeCountSql, params...)
 
-	br := dao.pool.SendBatch(context.Background(), batch)
+	br := dao.pool.SendBatch(ctx, batch)
 	defer br.Close()
 
 	resourcesRow := br.QueryRow()

--- a/pkg/database/dataValidation_test.go
+++ b/pkg/database/dataValidation_test.go
@@ -26,7 +26,7 @@ func Test_ClusterTotals(t *testing.T) {
 
 	mockPool.EXPECT().SendBatch(context.Background(), batch).Return(br)
 	// Execute function test.
-	resourceCount, edgeCount := dao.ClusterTotals("cluster_foo")
+	resourceCount, edgeCount := dao.ClusterTotals(context.Background(), "cluster_foo")
 
 	AssertEqual(t, resourceCount, 10, "resource count should be 10")
 	AssertEqual(t, edgeCount, 10, "edge count should be 10")

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -14,7 +14,9 @@ import (
 // Overrides the existing state of a cluster with the new data.
 // NOTE: This logic is not optimized. We use the simplest approach because this is a failsafe to
 //       recover from rare sync problems. At the moment this is good enough without adding complexity.
-func (dao *DAO) ResyncData(ctx context.Context, event model.SyncEvent, clusterName string, syncResponse *model.SyncResponse) {
+func (dao *DAO) ResyncData(ctx context.Context, event model.SyncEvent,
+	clusterName string, syncResponse *model.SyncResponse) {
+
 	defer metrics.SlowLog(fmt.Sprintf("Slow Resync from cluster %s", clusterName), 0)()
 	klog.Infof(
 		"Starting Resync of cluster %s. This is normal, but it could be a problem if it happens often.",

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -14,7 +14,7 @@ import (
 // Overrides the existing state of a cluster with the new data.
 // NOTE: This logic is not optimized. We use the simplest approach because this is a failsafe to
 //       recover from rare sync problems. At the moment this is good enough without adding complexity.
-func (dao *DAO) ResyncData(event model.SyncEvent, clusterName string, syncResponse *model.SyncResponse) {
+func (dao *DAO) ResyncData(ctx context.Context, event model.SyncEvent, clusterName string, syncResponse *model.SyncResponse) {
 	defer metrics.SlowLog(fmt.Sprintf("Slow Resync from cluster %s", clusterName), 0)()
 	klog.Infof(
 		"Starting Resync of cluster %s. This is normal, but it could be a problem if it happens often.",
@@ -25,7 +25,7 @@ func (dao *DAO) ResyncData(event model.SyncEvent, clusterName string, syncRespon
 	checkError(delResourcesSqlErr, fmt.Sprintf("Error creating query to delete cluster resources for %s.",
 		clusterName))
 
-	_, err := dao.pool.Exec(context.TODO(), delResourcesSql, args...)
+	_, err := dao.pool.Exec(ctx, delResourcesSql, args...)
 	if err != nil {
 		klog.Warningf("Error deleting resources during resync of cluster %s. Error: %+v", clusterName, err)
 	}
@@ -33,11 +33,11 @@ func (dao *DAO) ResyncData(event model.SyncEvent, clusterName string, syncRespon
 	delEdgesSql, args, delEdgesSqlErr := goquDelete("edges", "cluster", clusterName)
 	checkError(delEdgesSqlErr, fmt.Sprintf("Error creating query to delete edges for %s.", clusterName))
 
-	_, err = dao.pool.Exec(context.TODO(), delEdgesSql, args...)
+	_, err = dao.pool.Exec(ctx, delEdgesSql, args...)
 	if err != nil {
 		klog.Warningf("Error deleting edges during resync of cluster %s. Error: %+v", clusterName, err)
 	}
-	dao.SyncData(event, clusterName, syncResponse)
+	dao.SyncData(ctx, event, clusterName, syncResponse)
 
 	klog.V(1).Infof("Completed resync of cluster %s", clusterName)
 }

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -3,6 +3,7 @@
 package database
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -32,7 +33,7 @@ func Test_ResyncData(t *testing.T) {
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	dao.ResyncData(syncEvent, "test-cluster", response)
+	dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
 }
 
 func Test_ResyncData_errors(t *testing.T) {
@@ -54,5 +55,5 @@ func Test_ResyncData_errors(t *testing.T) {
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	dao.ResyncData(syncEvent, "test-cluster", response)
+	dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
 }

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -94,15 +94,6 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent, clusterName
 	// Flush remaining items in the batch.
 	batch.flush()
 
-	select {
-	case <-batch.cancel:
-		klog.Error("Unrecoverable error processing batch.")
-		return
-	default: //TODO need to wait async.
-		// Wait for all batches to complete.
-		batch.wg.Wait()
-	}
-
 	// The response fields below are redundant, these are more interesting for resync.
 	syncResponse.TotalAdded = len(event.AddResources) - len(syncResponse.AddErrors)
 	syncResponse.TotalUpdated = len(event.UpdateResources) - len(syncResponse.UpdateErrors)

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -13,7 +13,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent, clusterName string, syncResponse *model.SyncResponse) {
+func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
+	clusterName string, syncResponse *model.SyncResponse) {
+
 	defer metrics.SlowLog(fmt.Sprintf("Slow Sync from cluster %s.", clusterName), 0)()
 	batch := NewBatchWithRetry(ctx, dao, syncResponse)
 

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -94,6 +94,9 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent, clusterName
 	// Flush remaining items in the batch.
 	batch.flush()
 
+	// Wait for all batches to complete.
+	batch.wg.Wait()
+
 	// The response fields below are redundant, these are more interesting for resync.
 	syncResponse.TotalAdded = len(event.AddResources) - len(syncResponse.AddErrors)
 	syncResponse.TotalUpdated = len(event.UpdateResources) - len(syncResponse.UpdateErrors)

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -2,6 +2,7 @@
 package database
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -26,7 +27,7 @@ func Test_SyncData(t *testing.T) {
 
 	// Execute test
 	response := &model.SyncResponse{}
-	dao.SyncData(syncEvent, "test-cluster", response)
+	dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
 
 	// Assert
 	AssertEqual(t, response.TotalAdded, 2, "Incorrect number of resources added.")
@@ -59,7 +60,7 @@ func Test_Sync_With_Errors(t *testing.T) {
 
 	// Execute test
 	response := &model.SyncResponse{}
-	dao.SyncData(syncEvent, "test-cluster", response)
+	dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
 
 	// Assert
 	AssertEqual(t, len(response.AddErrors), 2, "Incorrect number of AddErrors.")

--- a/pkg/database/upsertCluster_test.go
+++ b/pkg/database/upsertCluster_test.go
@@ -223,13 +223,13 @@ func Test_DelClusterResources(t *testing.T) {
 	}
 	defer mockConn.Close(context.Background())
 	dao, mockPool := buildMockDAO(t)
-	mockPool.EXPECT().BeginTx(context.TODO(), pgx.TxOptions{}).Return(mockConn, nil)
+	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, nil)
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."edges" WHERE ("cluster" = 'name-foo')`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
 	mockConn.ExpectCommit()
 	// Execute function test.
-	dao.DeleteClusterAndResources(context.TODO(), clusterName, false)
+	dao.DeleteClusterAndResources(context.Background(), clusterName, false)
 
 	// After delete cluster method runs, clusters cache should still have an entry for cluster_foo
 	// as cluster itself is not deleted
@@ -248,7 +248,7 @@ func Test_DelCluster(t *testing.T) {
 	}
 	defer mockConn.Close(context.Background())
 	dao, mockPool := buildMockDAO(t)
-	mockPool.EXPECT().BeginTx(context.TODO(), pgx.TxOptions{}).Return(mockConn, nil)
+	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, nil)
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."edges" WHERE ("cluster" = 'name-foo')`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
@@ -260,7 +260,7 @@ func Test_DelCluster(t *testing.T) {
 	).Return(nil, nil)
 
 	// Execute function test.
-	dao.DeleteClusterAndResources(context.TODO(), clusterName, true)
+	dao.DeleteClusterAndResources(context.Background(), clusterName, true)
 
 	// After delete cluster method runs, clusters cache should not have an entry for cluster_foo
 	_, ok := ReadClustersCache("cluster__name-foo")
@@ -285,7 +285,7 @@ func Test_DelClusterResourcesError(t *testing.T) {
 	retryDel = 0 //count to keep track of failures/executions
 
 	// Expect BeginTx to be called twice. First time, return error. Second time, return success.
-	mockPool.EXPECT().BeginTx(context.TODO(), pgx.TxOptions{}).Times(2).
+	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Times(2).
 		DoAndReturn(func(con context.Context, txo pgx.TxOptions) (pgxmock.PgxConnIface, error) {
 
 			if retryDel == 0 { // First try to begin transaction
@@ -307,7 +307,7 @@ func Test_DelClusterResourcesError(t *testing.T) {
 	).Return(nil, nil)
 
 	// Expect deletecluster to be called twice. First time, return error. Second time, return success.
-	mockPool.EXPECT().Exec(context.TODO(),
+	mockPool.EXPECT().Exec(context.Background(),
 		gomock.Eq(`DELETE FROM "search"."resources" WHERE ("uid" = 'cluster__name-foo')`),
 		gomock.Eq([]interface{}{})).
 		Times(2). //expect it to be called twice
@@ -322,7 +322,7 @@ func Test_DelClusterResourcesError(t *testing.T) {
 			}
 		})
 	// Execute function test.
-	dao.DeleteClusterAndResources(context.TODO(), clusterName, true)
+	dao.DeleteClusterAndResources(context.Background(), clusterName, true)
 
 	// After delete cluster method runs, clusters cache should not have an entry for cluster_foo
 	_, ok := ReadClustersCache("cluster__name-foo")

--- a/pkg/server/syncHandler.go
+++ b/pkg/server/syncHandler.go
@@ -47,9 +47,9 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 	// 1. ReSync [ClearAll=true]  - It has the complete current state. It must overwrite any previous state.
 	// 2. Sync   [ClearAll=false] - This is the delta changes from the previous state.
 	if syncEvent.ClearAll {
-		s.Dao.ResyncData(syncEvent, clusterName, syncResponse)
+		s.Dao.ResyncData(r.Context(), syncEvent, clusterName, syncResponse)
 	} else {
-		s.Dao.SyncData(syncEvent, clusterName, syncResponse)
+		s.Dao.SyncData(r.Context(), syncEvent, clusterName, syncResponse)
 	}
 
 	totalResources, totalEdges := s.Dao.ClusterTotals(clusterName)

--- a/pkg/server/syncHandler.go
+++ b/pkg/server/syncHandler.go
@@ -52,7 +52,7 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 		s.Dao.SyncData(r.Context(), syncEvent, clusterName, syncResponse)
 	}
 
-	totalResources, totalEdges := s.Dao.ClusterTotals(clusterName)
+	totalResources, totalEdges := s.Dao.ClusterTotals(r.Context(), clusterName)
 	syncResponse.TotalResources = totalResources
 	syncResponse.TotalEdges = totalEdges
 


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-5168

### Description of changes
- Use the context from incoming http request for the DB queries associated with the request. With this we can ensure that if the request is cancelled, the database queries triggered by it also get cancelled.
