### PR TITLE
ACM-5168: Improve handling of errors from database

### DIFF
--- a/pkg/database/batch.go
+++ b/pkg/database/batch.go
@@ -46,9 +46,9 @@ func NewBatchWithRetry(ctx context.Context, dao *DAO, syncResponse *model.SyncRe
 }
 
 // Adds a query to the queue and check if there's enough items to process the batch.
-func (b *batchWithRetry) Queue(item batchItem) {
+func (b *batchWithRetry) Queue(item batchItem) error {
 	if b.connError != nil { // Can't queue more items after DB connection error.
-		return // TODO: return the error.
+		return b.connError
 	}
 	b.items = append(b.items, item)
 
@@ -58,6 +58,7 @@ func (b *batchWithRetry) Queue(item batchItem) {
 		b.wg.Add(1)
 		go b.sendBatch(items) // nolint: errcheck
 	}
+	return nil
 }
 
 // Sends a batch to the database. If the batch results in an error, we divide

--- a/pkg/database/batch.go
+++ b/pkg/database/batch.go
@@ -47,7 +47,7 @@ func NewBatchWithRetry(ctx context.Context, dao *DAO, syncResponse *model.SyncRe
 
 // Adds a query to the queue and check if there's enough items to process the batch.
 func (b *batchWithRetry) Queue(item batchItem) {
-	if b.connError == nil { // Can't queue more items after DB connection error.
+	if b.connError != nil { // Can't queue more items after DB connection error.
 		return // TODO: return the error.
 	}
 	b.items = append(b.items, item)

--- a/pkg/database/batch_test.go
+++ b/pkg/database/batch_test.go
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package database
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_QueueWithErrors(t *testing.T) {
+	mock := &batchWithRetry{
+		connError: errors.New("failed to connect"),
+	}
+
+	result := mock.Queue(batchItem{})
+
+	assert.NotNil(t, result)
+}

--- a/pkg/database/dataValidation.go
+++ b/pkg/database/dataValidation.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Query resource and edge count for a cluster. Used for data validation.
-func (dao *DAO) ClusterTotals(ctx context.Context, clusterName string) (resources int, edges int) {
+func (dao *DAO) ClusterTotals(ctx context.Context, clusterName string) (resources int, edges int, e error) {
 	batch := &pgx.Batch{}
 
 	// Sample query: SELECT count(*) FROM search.resources WHERE cluster=$1
@@ -47,12 +47,14 @@ func (dao *DAO) ClusterTotals(ctx context.Context, clusterName string) (resource
 	resourcesErr := resourcesRow.Scan(&resources)
 	if resourcesErr != nil {
 		klog.Error("Error reading total resources for cluster ", clusterName, " err: ", resourcesErr)
+		return resources, edges, resourcesErr
 	}
 	edgesRow := br.QueryRow()
 	edgesErr := edgesRow.Scan(&edges)
 	if edgesErr != nil {
 		klog.Error("Error reading total edges for cluster ", clusterName, " err: ", edgesErr)
+		return resources, edges, edgesErr
 	}
 
-	return resources, edges
+	return resources, edges, nil
 }

--- a/pkg/database/dataValidation_test.go
+++ b/pkg/database/dataValidation_test.go
@@ -4,9 +4,12 @@ package database
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	pgx "github.com/jackc/pgx/v4"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,4 +35,28 @@ func Test_ClusterTotals(t *testing.T) {
 	AssertEqual(t, resourceCount, 10, "resource count should be 10")
 	AssertEqual(t, edgeCount, 10, "edge count should be 10")
 	assert.Nil(t, err)
+}
+
+func Test_ClusterTotals_withErrorQueryingResources(t *testing.T) {
+	// Prepare a mock DAO instance
+	dao, mockPool := buildMockDAO(t)
+
+	// mock Result
+	br := BatchResults{
+		MockRows: MockRows{
+			mockData:        []map[string]interface{}{{"count": 10}},
+			index:           1,
+			mockErrorOnScan: errors.New("unexpected EOF"),
+		},
+	}
+	// mock queries
+	mockPool.EXPECT().SendBatch(context.Background(), gomock.Any()).Return(br)
+
+	// Execute function test.
+	resourceCount, edgeCount, err := dao.ClusterTotals(context.Background(), "cluster_foo")
+
+	// Validate
+	assert.Equal(t, resourceCount, 0)
+	assert.Equal(t, edgeCount, 0)
+	assert.NotNil(t, err)
 }

--- a/pkg/database/dataValidation_test.go
+++ b/pkg/database/dataValidation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	pgx "github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ClusterTotals(t *testing.T) {
@@ -26,8 +27,9 @@ func Test_ClusterTotals(t *testing.T) {
 
 	mockPool.EXPECT().SendBatch(context.Background(), batch).Return(br)
 	// Execute function test.
-	resourceCount, edgeCount := dao.ClusterTotals(context.Background(), "cluster_foo")
+	resourceCount, edgeCount, err := dao.ClusterTotals(context.Background(), "cluster_foo")
 
 	AssertEqual(t, resourceCount, 10, "resource count should be 10")
 	AssertEqual(t, edgeCount, 10, "edge count should be 10")
+	assert.Nil(t, err)
 }

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stolostron/search-indexer/pkg/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ResyncData(t *testing.T) {
@@ -33,7 +34,9 @@ func Test_ResyncData(t *testing.T) {
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
+
+	assert.Nil(t, err)
 }
 
 func Test_ResyncData_errors(t *testing.T) {
@@ -55,5 +58,7 @@ func Test_ResyncData_errors(t *testing.T) {
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
+
+	assert.NotNil(t, err)
 }

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
-	clusterName string, syncResponse *model.SyncResponse) {
+	clusterName string, syncResponse *model.SyncResponse) error {
 
 	defer metrics.SlowLog(fmt.Sprintf("Slow Sync from cluster %s.", clusterName), 0)()
 	batch := NewBatchWithRetry(ctx, dao, syncResponse)
@@ -107,4 +107,5 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	syncResponse.TotalEdgesDeleted = len(event.DeleteEdges) - len(syncResponse.DeleteEdgeErrors)
 
 	klog.V(1).Infof("Completed sync of cluster %s", clusterName)
+	return batch.connError
 }

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -18,12 +18,13 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 
 	defer metrics.SlowLog(fmt.Sprintf("Slow Sync from cluster %s.", clusterName), 0)()
 	batch := NewBatchWithRetry(ctx, dao, syncResponse)
+	var queueErr error
 
 	// ADD RESOURCES
 	// In case of conflict update only if data has changed
 	for _, resource := range event.AddResources {
 		data, _ := json.Marshal(resource.Properties)
-		batch.Queue(batchItem{
+		queueErr = batch.Queue(batchItem{
 			action: "addResource",
 			query: `INSERT into search.resources as r values($1,$2,$3) ON CONFLICT (uid) 
 			DO UPDATE SET data=$3 WHERE r.uid=$1 and r.data IS DISTINCT FROM $3`,
@@ -37,7 +38,7 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	// The uid and cluster fields will never get updated for a resource.
 	for _, resource := range event.UpdateResources {
 		data, _ := json.Marshal(resource.Properties)
-		batch.Queue(batchItem{
+		queueErr = batch.Queue(batchItem{
 			action: "updateResource",
 			query:  "UPDATE search.resources SET data=$2 WHERE uid=$1",
 			uid:    resource.UID,
@@ -57,13 +58,13 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 
 		// TODO: Need better safety for delete errors.
 		// The current retry logic won't work well if there's an error here.
-		batch.Queue(batchItem{
+		queueErr = batch.Queue(batchItem{
 			action: "deleteResource",
 			query:  fmt.Sprintf("DELETE from search.resources WHERE uid IN (%s)", paramStr),
 			uid:    fmt.Sprintf("%s", uids),
 			args:   uids,
 		})
-		batch.Queue(batchItem{
+		queueErr = batch.Queue(batchItem{
 			action: "deleteResource",
 			query:  fmt.Sprintf("DELETE from search.edges WHERE sourceId IN (%s) OR destId IN (%s)", paramStr, paramStr),
 			uid:    fmt.Sprintf("%s", uids),
@@ -74,7 +75,7 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	// ADD EDGES
 	// Nothing to update in case of conflict as resource kind cannot change
 	for _, edge := range event.AddEdges {
-		batch.Queue(batchItem{
+		queueErr = batch.Queue(batchItem{
 			action: "addEdge",
 			query:  "INSERT into search.edges values($1,$2,$3,$4,$5,$6) ON CONFLICT (sourceid, destid, edgetype) DO NOTHING",
 			uid:    edge.SourceUID,
@@ -86,7 +87,7 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 
 	// DELETE EDGES
 	for _, edge := range event.DeleteEdges {
-		batch.Queue(batchItem{
+		queueErr = batch.Queue(batchItem{
 			action: "deleteEdge",
 			query:  "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3",
 			uid:    edge.SourceUID,
@@ -98,6 +99,10 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 
 	// Wait for all batches to complete.
 	batch.wg.Wait()
+	if queueErr != nil {
+		klog.V(1).Infof("Completed sync of cluster [%s] with errors.", clusterName)
+		return queueErr
+	}
 
 	// The response fields below are redundant, these are more interesting for resync.
 	syncResponse.TotalAdded = len(event.AddResources) - len(syncResponse.AddErrors)

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -58,7 +58,7 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 
 		// TODO: Need better safety for delete errors.
 		// The current retry logic won't work well if there's an error here.
-		queueErr = batch.Queue(batchItem{
+		err := batch.Queue(batchItem{
 			action: "deleteResource",
 			query:  fmt.Sprintf("DELETE from search.resources WHERE uid IN (%s)", paramStr),
 			uid:    fmt.Sprintf("%s", uids),
@@ -70,6 +70,9 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 			uid:    fmt.Sprintf("%s", uids),
 			args:   uids,
 		})
+		if err != nil {
+			queueErr = err
+		}
 	}
 
 	// ADD EDGES

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -98,5 +98,5 @@ func Test_Sync_With_OnClose_Errors(t *testing.T) {
 	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
 
 	// Assert
-	assert.Nil(t, err) // FIXME, should be NotNil
+	assert.NotNil(t, err)
 }

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -47,8 +47,7 @@ func Test_Sync_With_Exec_Errors(t *testing.T) {
 
 	// Mock PosgreSQL calls
 	br := BatchResults{
-		mockErrorOnClose: false,
-		mockErrorOnExec:  true,
+		mockErrorOnExec: true,
 	}
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(7)
 
@@ -66,11 +65,11 @@ func Test_Sync_With_Exec_Errors(t *testing.T) {
 
 	// Assert
 	assert.Nil(t, err)
-	// AssertEqual(t, len(response.AddErrors), 2, "Incorrect number of AddErrors.")
-	// AssertEqual(t, len(response.UpdateErrors), 1, "Incorrect number of UpdateErrors.")
-	// AssertEqual(t, len(response.DeleteErrors), 2, "Incorrect number of DeleteErrors.")
-	// AssertEqual(t, len(response.AddEdgeErrors), 1, "Incorrect number of AddEdgeErrors.")
-	// AssertEqual(t, len(response.DeleteEdgeErrors), 1, "Incorrect number of DeleteEdgeErrors.")
+	AssertEqual(t, len(response.AddErrors), 2, "Incorrect number of AddErrors.")
+	AssertEqual(t, len(response.UpdateErrors), 1, "Incorrect number of UpdateErrors.")
+	AssertEqual(t, len(response.DeleteErrors), 2, "Incorrect number of DeleteErrors.")
+	AssertEqual(t, len(response.AddEdgeErrors), 1, "Incorrect number of AddEdgeErrors.")
+	AssertEqual(t, len(response.DeleteEdgeErrors), 1, "Incorrect number of DeleteEdgeErrors.")
 }
 
 func Test_Sync_With_OnClose_Errors(t *testing.T) {
@@ -81,7 +80,6 @@ func Test_Sync_With_OnClose_Errors(t *testing.T) {
 	// Mock PosgreSQL calls
 	br := BatchResults{
 		mockErrorOnClose: true,
-		mockErrorOnExec:  false,
 	}
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(7)
 

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stolostron/search-indexer/pkg/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_SyncData(t *testing.T) {
@@ -27,9 +28,10 @@ func Test_SyncData(t *testing.T) {
 
 	// Execute test
 	response := &model.SyncResponse{}
-	dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
 
 	// Assert
+	assert.Nil(t, err)
 	AssertEqual(t, response.TotalAdded, 2, "Incorrect number of resources added.")
 	AssertEqual(t, response.TotalUpdated, 1, "Incorrect number of resources updated.")
 	AssertEqual(t, response.TotalDeleted, 1, "Incorrect number of resources deleted.")
@@ -38,14 +40,14 @@ func Test_SyncData(t *testing.T) {
 }
 
 // Test for the error path.
-func Test_Sync_With_Errors(t *testing.T) {
+func Test_Sync_With_Exec_Errors(t *testing.T) {
 	// Prepare a mock DAO instance
 	dao, mockPool := buildMockDAO(t)
 	dao.batchSize = 1
 
 	// Mock PosgreSQL calls
 	br := BatchResults{
-		mockErrorOnClose: true,
+		mockErrorOnClose: false,
 		mockErrorOnExec:  true,
 	}
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(7)
@@ -60,12 +62,41 @@ func Test_Sync_With_Errors(t *testing.T) {
 
 	// Execute test
 	response := &model.SyncResponse{}
-	dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
 
 	// Assert
-	AssertEqual(t, len(response.AddErrors), 2, "Incorrect number of AddErrors.")
-	AssertEqual(t, len(response.UpdateErrors), 1, "Incorrect number of UpdateErrors.")
-	AssertEqual(t, len(response.DeleteErrors), 2, "Incorrect number of DeleteErrors.")
-	AssertEqual(t, len(response.AddEdgeErrors), 1, "Incorrect number of AddEdgeErrors.")
-	AssertEqual(t, len(response.DeleteEdgeErrors), 1, "Incorrect number of DeleteEdgeErrors.")
+	assert.Nil(t, err)
+	// AssertEqual(t, len(response.AddErrors), 2, "Incorrect number of AddErrors.")
+	// AssertEqual(t, len(response.UpdateErrors), 1, "Incorrect number of UpdateErrors.")
+	// AssertEqual(t, len(response.DeleteErrors), 2, "Incorrect number of DeleteErrors.")
+	// AssertEqual(t, len(response.AddEdgeErrors), 1, "Incorrect number of AddEdgeErrors.")
+	// AssertEqual(t, len(response.DeleteEdgeErrors), 1, "Incorrect number of DeleteEdgeErrors.")
+}
+
+func Test_Sync_With_OnClose_Errors(t *testing.T) {
+	// Prepare a mock DAO instance
+	dao, mockPool := buildMockDAO(t)
+	dao.batchSize = 1
+
+	// Mock PosgreSQL calls
+	br := BatchResults{
+		mockErrorOnClose: true,
+		mockErrorOnExec:  false,
+	}
+	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(7)
+
+	// Prepare Request data
+	data, _ := os.Open("./mocks/simple.json")
+	var syncEvent model.SyncEvent
+	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
+
+	// Supress console output to prevent log messages from polluting test output.
+	defer SupressConsoleOutput()()
+
+	// Execute test
+	response := &model.SyncResponse{}
+	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+
+	// Assert
+	assert.Nil(t, err) // FIXME, should be NotNil
 }

--- a/pkg/database/testHelper_test.go
+++ b/pkg/database/testHelper_test.go
@@ -85,9 +85,10 @@ func buildMockDAO(t *testing.T) (DAO, *pgxpoolmock.MockPgxPool) {
 }
 
 type MockRows struct {
-	mockData      []map[string]interface{}
-	index         int
-	columnHeaders []string
+	mockData        []map[string]interface{}
+	index           int
+	columnHeaders   []string
+	mockErrorOnScan error
 }
 
 func (r *MockRows) Close() {}
@@ -104,7 +105,9 @@ func (r *MockRows) Next() bool {
 }
 
 func (r *MockRows) Scan(dest ...interface{}) error {
-	// For Test_UpsertCluster_Update1 test
+	if r.mockErrorOnScan != nil {
+		return r.mockErrorOnScan
+	}
 
 	if len(dest) == 2 { // uid and data
 		*dest[0].(*string) = r.mockData[r.index-1]["uid"].(string)

--- a/pkg/database/testHelper_test.go
+++ b/pkg/database/testHelper_test.go
@@ -69,7 +69,7 @@ func (s BatchResults) QueryFunc(scans []interface{}, f func(pgx.QueryFuncRow) er
 }
 func (s BatchResults) Close() error {
 	if s.mockErrorOnClose {
-		return fmt.Errorf("MockError")
+		return fmt.Errorf("unexpected EOF")
 	}
 	return nil
 }

--- a/pkg/server/syncHandler.go
+++ b/pkg/server/syncHandler.go
@@ -54,11 +54,16 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		klog.Warningf("Responding with error to request from [%s].  Error: %s", clusterName, err)
 		http.Error(w, "Server error while processing the request.", http.StatusInternalServerError)
-		// http.Error(w, "Database unavailable.", http.StatusServiceUnavailable)
 		return
 	}
 
-	totalResources, totalEdges, err := s.Dao.ClusterTotals(r.Context(), clusterName)
+	// Get the total cluster resources for validation by the collector.
+	totalResources, totalEdges, validateErr := s.Dao.ClusterTotals(r.Context(), clusterName)
+	if validateErr != nil {
+		klog.Warningf("Responding with error to request from [%s].  Error: %s", clusterName, err)
+		http.Error(w, "Server error while processing the request.", http.StatusInternalServerError)
+		return
+	}
 	syncResponse.TotalResources = totalResources
 	syncResponse.TotalEdges = totalEdges
 

--- a/pkg/server/syncHandler_test.go
+++ b/pkg/server/syncHandler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stolostron/search-indexer/pkg/config"
 	"github.com/stolostron/search-indexer/pkg/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_syncRequest(t *testing.T) {
@@ -52,6 +53,32 @@ func Test_syncRequest(t *testing.T) {
 	if fmt.Sprintf("%+v", decodedResp) != fmt.Sprintf("%+v", expected) {
 		t.Errorf("Incorrect response body.\n expected '%+v'\n received '%+v'", expected, decodedResp)
 	}
+}
+
+func Test_syncRequest_withError(t *testing.T) {
+	// Read mock request body.
+	body, readErr := os.Open("./mocks/simple.json")
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	responseRecorder := httptest.NewRecorder()
+
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	router := mux.NewRouter()
+
+	// Create server with mock database.
+	server, mockPool := buildMockServer(t)
+
+	br := &batchResults{rows: []int{5, 3}, mockErrorOnClose: true}
+	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(2)
+
+	router.HandleFunc("/aggregator/clusters/{id}/sync", server.SyncResources)
+	router.ServeHTTP(responseRecorder, request)
+
+	assert.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
+
+	bodyString, _ := responseRecorder.Body.ReadString(byte(0))
+	assert.Equal(t, "Server error while processing the request.\n", bodyString)
 }
 
 func Test_resyncRequest(t *testing.T) {

--- a/pkg/server/testHelper_test.go
+++ b/pkg/server/testHelper_test.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/driftprogramming/pgxpoolmock"
@@ -29,14 +30,23 @@ func (r *Row) Scan(dest ...interface{}) error {
 // https://github.com/jackc/pgx/blob/master/batch.go#L34
 // ===========================================================
 type batchResults struct {
-	rows  []int
-	index int
+	rows             []int
+	index            int
+	mockErrorOnClose bool // Return an error on Close()
+	mockErrorOnExec  bool // Return an error on Exec()
+	mockErrorOnQuery bool // Return an error on Query()
 }
 
 func (br *batchResults) Exec() (pgconn.CommandTag, error) {
+	if br.mockErrorOnExec {
+		return nil, errors.New("unexpected EOF")
+	}
 	return nil, nil
 }
 func (br *batchResults) Query() (pgx.Rows, error) {
+	if br.mockErrorOnQuery {
+		return nil, errors.New("unexpected EOF")
+	}
 	return nil, nil
 }
 func (br *batchResults) QueryRow() pgx.Row {
@@ -48,6 +58,9 @@ func (br *batchResults) QueryFunc(scans []interface{}, f func(pgx.QueryFuncRow) 
 	return nil, nil
 }
 func (br *batchResults) Close() error {
+	if br.mockErrorOnClose {
+		return errors.New("unexpected EOF")
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-5168

### Description of changes
- Respond with error if resync is unable to delete existing data in postgres.
- Respond with error if a batch operation fails because "failed to connect".
- Respond with error if unable to get the resource totals for validation.
