### PR TITLE
[release-2.7] ACM-7320: Reduce default REQUEST_LIMIT to 20

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,7 +65,7 @@ func new() *Config {
 		MaxBackoffMS: getEnvAsInt("MAX_BACKOFF_MS", 300000), // 5 min
 		// EdgeBuildRateMS:       getEnvAsInt("EDGE_BUILD_RATE_MS", 15000), // 15 sec
 		RediscoverRateMS: getEnvAsInt("REDISCOVER_RATE_MS", 300000), // 5 min
-		RequestLimit:     getEnvAsInt("REQUEST_LIMIT", 25),          // Limit to 25 to keep memory below 1GB.
+		RequestLimit:     getEnvAsInt("REQUEST_LIMIT", 20),          // Limit to 20 to keep memory below 1GB.
 		// SkipClusterValidation: getEnvAsBool("SKIP_CLUSTER_VALIDATION", false),
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,7 +65,7 @@ func new() *Config {
 		MaxBackoffMS: getEnvAsInt("MAX_BACKOFF_MS", 300000), // 5 min
 		// EdgeBuildRateMS:       getEnvAsInt("EDGE_BUILD_RATE_MS", 15000), // 15 sec
 		RediscoverRateMS: getEnvAsInt("REDISCOVER_RATE_MS", 300000), // 5 min
-		RequestLimit:     getEnvAsInt("REQUEST_LIMIT", 50),          // Limit to 50 to keep memory below 1GB.
+		RequestLimit:     getEnvAsInt("REQUEST_LIMIT", 25),          // Limit to 25 to keep memory below 1GB.
 		// SkipClusterValidation: getEnvAsBool("SKIP_CLUSTER_VALIDATION", false),
 	}
 


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-7320

### Description of changes
- Reduce the default REQUEST_LIMIT to 20.
- The more conservative request limit helps reduce errors and memory problems on the indexer. By reducing the number of concurrent requests we have much better chances that the accepted requests will complete fast.

A similar change has been merged for release-2.8 and main.
- #111 
- #109 
