### PR TITLE
Restore konflux PR#139 (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/stolostron/search-indexer
 COPY . .
 RUN CGO_ENABLED=1 go build -trimpath -o main main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Restore konflux update, merge to `main` instead of `release-2.12`. Merging to release branch breaks the fast-forward.
- PR #139 
