### PR TITLE
add red-hat-konflux bot as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,4 @@ approvers:
 
 reviewers:
   - dislbenn
+  - red-hat-konflux


### PR DESCRIPTION
### Description of changes
- Added red-hat-konflux bot to reviewers so it can hopefully trigger tests on the konflux prs.