### PR TITLE
ACM-16129: large request limiter middleware to limit too many large requests

### DIFF
--- a/pkg/server/largeRequestLimiter.go
+++ b/pkg/server/largeRequestLimiter.go
@@ -1,0 +1,47 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package server
+
+import (
+	"k8s.io/klog/v2"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/mux"
+	"github.com/stolostron/search-indexer/pkg/config"
+)
+
+var largeRequestCountTracker int
+var largeRequestCountTrackerLock = sync.RWMutex{}
+
+// Checks if we are able to accept the incoming request based upon request size
+func largeRequestLimiterMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		clusterName := params["id"]
+		if r.ContentLength > int64(config.Cfg.LargeRequestLimit) {
+			largeRequestCountTrackerLock.RLock()
+			largeRequestCount := largeRequestCountTracker
+			largeRequestCountTrackerLock.RUnlock()
+
+			if largeRequestCount >= config.Cfg.LargeRequestLimit {
+				klog.Warningf("Rejecting large request from %s because there's too many large requests processing. Request size: %dMB",
+					clusterName, r.ContentLength/1024/1024)
+				http.Error(w, "Too many large requests currently processing, retry later.", http.StatusTooManyRequests)
+				return
+			}
+
+			largeRequestCountTrackerLock.Lock()
+			largeRequestCountTracker++
+			largeRequestCountTrackerLock.Unlock()
+
+			defer func() {
+				largeRequestCountTrackerLock.Lock()
+				largeRequestCountTracker--
+				largeRequestCountTrackerLock.Unlock()
+			}()
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/server/largeRequestLimiter_test.go
+++ b/pkg/server/largeRequestLimiter_test.go
@@ -1,0 +1,69 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package server
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_largeReqeustLimiterMiddleware(t *testing.T) {
+	// Given: no large requests being processed and a large request
+	largeRequestCountTracker = 0
+	largeRequestLimiterHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	largeRequest := make([]byte, 1024*1024*21)
+	for i := range largeRequest {
+		largeRequest[i] = 0
+	}
+	reader := bytes.NewReader(largeRequest)
+	req := httptest.NewRequest("POST", "https://localhost:3010/aggregator/clusters/cluster1/sync", reader)
+	res := httptest.NewRecorder()
+
+	// When: we process the request
+	largeRequestLimiterHandler(res, req)
+	middleware := largeRequestLimiterMiddleware(largeRequestLimiterHandler)
+	middleware.ServeHTTP(res, req)
+
+	// Then: the request is processed without err
+	assert.Equal(t, http.StatusOK, res.Code)
+}
+
+func Test_largeRequestLimiterMiddleware_tooManyRequests(t *testing.T) {
+	// Given: too many large requests being processed and a large request
+	largeRequestCountTracker = 10
+	largeRequestLimiterHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	largeRequest := make([]byte, 1024*1024*21)
+	for i := range largeRequest {
+		largeRequest[i] = 0
+	}
+	reader := bytes.NewReader(largeRequest)
+	req := httptest.NewRequest("POST", "https://localhost:3010/aggregator/clusters/cluster1/sync", reader)
+	res := httptest.NewRecorder()
+
+	// When: we get process the request
+	largeRequestLimiterHandler(res, req)
+	middleware := largeRequestLimiterMiddleware(largeRequestLimiterHandler)
+	middleware.ServeHTTP(res, req)
+
+	// Then: the request is rejected with err
+	assert.Equal(t, http.StatusTooManyRequests, res.Code)
+}
+
+func Test_largeRequestLimiterMiddleware_smallRequest(t *testing.T) {
+	// Given: too many large requests being processed and a small request
+	largeRequestCountTracker = 10
+	largeRequestLimiterHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	req := httptest.NewRequest("POST", "https://localhost:3010/aggregator/clusters/cluster1/sync", nil)
+	res := httptest.NewRecorder()
+
+	// When: we process the request
+	largeRequestLimiterHandler(res, req)
+	middleware := largeRequestLimiterMiddleware(largeRequestLimiterHandler)
+	middleware.ServeHTTP(res, req)
+
+	// Then: the request is processed without err
+	assert.Equal(t, http.StatusOK, res.Code)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -30,6 +30,7 @@ func (s *ServerConfig) StartAndListen(ctx context.Context) {
 	syncSubrouter := router.PathPrefix("/aggregator").Subrouter()
 	syncSubrouter.Use(metrics.PrometheusMiddleware)
 	syncSubrouter.Use(requestLimiterMiddleware)
+	syncSubrouter.Use(largeRequestLimiterMiddleware)
 	syncSubrouter.HandleFunc("/clusters/{id}/sync", s.SyncResources).Methods("POST")
 
 	// Configure TLS


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-0000](https://issues.redhat.com/browse/ACM-16129

### Description of changes
- Added large request limiter middleware to limit the number of large requests being processed to help control memory spikes from large requests.
