### PR TITLE
ACM-16129 faster memory deallocation

### DIFF
--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -54,9 +54,8 @@ func (dao *DAO) resetResources(ctx context.Context, resources []model.Resource, 
 	batch := NewBatchWithRetry(ctx, dao, syncResponse)
 
 	incomingResMap := make(map[string]*model.Resource, len(resources))
-	for i, resource := range resources {
-		incomingResMap[resource.UID] = &resources[i]
-		resources[i] = model.Resource{}
+	for i := range resources {
+		incomingResMap[resources[i].UID] = &resources[i]
 	}
 	resourcesToDelete := make([]interface{}, 0)
 	resourcesToUpdate := make([]*model.Resource, 0)

--- a/pkg/server/syncHandler.go
+++ b/pkg/server/syncHandler.go
@@ -46,6 +46,7 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 	// The collector sends 2 types of requests:
 	// 1. ReSync [ClearAll=true]  - It has the complete current state. It must overwrite any previous state.
 	// 2. Sync   [ClearAll=false] - This is the delta changes from the previous state.
+	lenAddResources := len(syncEvent.AddResources)
 	if syncEvent.ClearAll {
 		err = s.Dao.ResyncData(r.Context(), syncEvent, clusterName, syncResponse)
 	} else {
@@ -79,6 +80,6 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 
 	// Log request.
 	klog.V(5).Infof("Request from [%12s] took [%v] clearAll [%t] addTotal [%d]",
-		clusterName, time.Since(start), syncEvent.ClearAll, len(syncEvent.AddResources))
+		clusterName, time.Since(start), syncEvent.ClearAll, lenAddResources)
 	// klog.V(5).Infof("Response for [%s]: %+v", clusterName, syncResponse)
 }


### PR DESCRIPTION
### Related Issue
[<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-16129](https://issues.redhat.com/browse/ACM-16129)

### Description of changes
- Replace original resource with empty model.Resource{} after copying from it so object can be garbage collected sooner.
- Avoids unnecessarily unmarshaling resources if the resource is destined to be deleted.

These types of requests, as demonstrated by benchmarking with SNO-100K, still result in memory spikes, but these changes free up memory sooner. In the event of simultaneous multi-cluster resyncs, we hope with memory spikes not lasting as long, there will be less overlap of memory spikes from simultaneous requests.

Before:
syncResources start                         	Alloc = 2 MiB   objects: 18368  NumGC = 5
syncResources start (GC)                    	Alloc = 2 MiB   objects: 17993  NumGC = 6
**resetResources start                        	Alloc = 234 MiB objects: 3713571    	NumGC = 12**
resetResources start (GC)                   	Alloc = 122 MiB objects: 2681486    	NumGC = 13
resetResources end                          	Alloc = 179 MiB objects: 2895169    	NumGC = 19
resetResources end (GC)                     	Alloc = 123 MiB objects: 2683766    	NumGC = 20
resetEdges start                            	Alloc = 123 MiB objects: 2683772    	NumGC = 20
resetEdges start (GC)                       	Alloc = 123 MiB objects: 2683744    	NumGC = 21
resetEdges end                              	Alloc = 163 MiB objects: 3246659    	NumGC = 22
resetEdges end (GC)                         	Alloc = 123 MiB objects: 2683828    	NumGC = 23
syncResources end                           	Alloc = 123 MiB objects: 2684221    	NumGC = 23
syncResources end (GC)                      	Alloc = 123 MiB objects: 2683959    	NumGC = 24

After:
syncResources start                             Alloc = 2 MiB   objects: 19244  NumGC = 5
syncResources start (GC)                        Alloc = 2 MiB   objects: 18004  NumGC = 6
**resetResources start                            Alloc = 234 MiB objects: 3713547        NumGC = 12**
resetResources start (GC)                       Alloc = 122 MiB objects: 2681478        NumGC = 13
resetResources end                              Alloc = 39 MiB  objects: 346265 NumGC = 25
resetResources end (GC)                         Alloc = 13 MiB  objects: 90535  NumGC = 26
resetEdges start                                Alloc = 13 MiB  objects: 90539  NumGC = 26
resetEdges start (GC)                           Alloc = 13 MiB  objects: 90527  NumGC = 27
resetEdges end                                  Alloc = 28 MiB  objects: 234947 NumGC = 34
resetEdges end (GC)                             Alloc = 13 MiB  objects: 90630  NumGC = 35
syncResources end                               Alloc = 13 MiB  objects: 91011  NumGC = 35
syncResources end (GC)                          Alloc = 13 MiB  objects: 90748  NumGC = 36