### PR TITLE
ACM-16129 ReSync handling from []byte

### DIFF
--- a/pkg/database/batch.go
+++ b/pkg/database/batch.go
@@ -5,6 +5,7 @@ package database
 import (
 	"context"
 	"errors"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -64,7 +65,10 @@ func (b *batchWithRetry) Queue(item batchItem) error {
 // Sends a batch to the database. If the batch results in an error, we divide
 // the batch into smaller batches and retry until we isolate the erroring query.
 func (b *batchWithRetry) sendBatch(items []batchItem) error {
-	defer b.wg.Done()
+	defer func() {
+		b.wg.Done()
+		runtime.GC()
+	}()
 
 	batch := &pgx.Batch{}
 	for _, item := range items {

--- a/pkg/database/goquHelper.go
+++ b/pkg/database/goquHelper.go
@@ -50,6 +50,19 @@ func useGoqu(query string, params []interface{}) (q string, p []interface{}, er 
 		q, p, er = dialect.From(resources).
 			Delete().Where(goqu.C("uid").In(params)).ToSQL()
 
+	case "DELETE FROM search.resources WHERE cluster=$1 AND uid!='cluster__$1'":
+		q, p, er = dialect.From(resources).
+			Delete().Where(
+			goqu.Or(goqu.C("cluster").Eq(params[0])),
+			goqu.C("uid").Neq(fmt.Sprintf("cluster__%s", params[0]))).
+			ToSQL()
+
+	case "DELETE FROM search.edges WHERE cluster=$1 AND edgetype!='intercluster'":
+		q, p, er = dialect.From(edges).
+			Delete().Where(
+			goqu.And(goqu.C("edgetype").Neq("intercluster"),
+				goqu.C("cluster").Eq(params[0]))).ToSQL()
+
 	case "DELETE from search.edges WHERE sourceid IN ($1) OR destid IN ($1)":
 		q, p, er = dialect.From(edges).
 			Delete().Where(

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -3,10 +3,11 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
+	"io"
 	"time"
 
 	"github.com/stolostron/search-indexer/pkg/metrics"
@@ -16,21 +17,21 @@ import (
 
 // Reset data for the cluster to the incoming state.
 func (dao *DAO) ResyncData(ctx context.Context, event model.SyncEvent,
-	clusterName string, syncResponse *model.SyncResponse) error {
+	clusterName string, syncResponse *model.SyncResponse, body []byte) error {
 
 	defer metrics.SlowLog(fmt.Sprintf("Slow resync from %12s. RequestId: %d", clusterName, event.RequestId), 0)()
 	klog.Infof(
 		"Starting resync from %12s. This is normal, but it could be a problem if it happens often.", clusterName)
 
 	// Reset resources
-	err := dao.resetResources(ctx, event.AddResources, clusterName, syncResponse)
+	err := dao.resetResources(ctx, clusterName, syncResponse, body)
 	if err != nil {
 		klog.Warningf("Error resyncing resources for cluster %12s. Error: %+v", clusterName, err)
 		return err
 	}
 
 	// Reset edges
-	err = dao.resetEdges(ctx, event.AddEdges, clusterName, syncResponse)
+	err = dao.resetEdges(ctx, clusterName, syncResponse, body)
 	if err != nil {
 		klog.Warningf("Error resyncing edges for cluster %12s. Error: %+v", clusterName, err)
 		return err
@@ -40,151 +41,141 @@ func (dao *DAO) ResyncData(ctx context.Context, event model.SyncEvent,
 	return nil
 }
 
+func decodeAddResources(body []byte, key string, clusterName string, batch batchWithRetry, syncResponse *model.SyncResponse) (int, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	count := 0
+
+	// read opening {
+	if _, err := dec.Token(); err != nil {
+		return count, fmt.Errorf("error decoding SyncEvent token: %v", err)
+	}
+	for {
+		// read tokens until we get to addResources
+		field, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if field == key {
+			// read opening [
+			if _, err = dec.Token(); err != nil {
+				return count, fmt.Errorf("error reading resource opening token: %v", err)
+			}
+			for dec.More() {
+				var resource model.Resource
+				if err = dec.Decode(&resource); err != nil {
+					return count, fmt.Errorf("error decoding resource from request: %v", err)
+				}
+				// insert
+				props, _ := json.Marshal(resource.Properties)
+				query, params, err := useGoqu(
+					"INSERT into search.resources values($1,$2,$3) ON CONFLICT (uid) DO NOTHING",
+					[]interface{}{resource.UID, clusterName, string(props)})
+				if err == nil {
+					queueErr := batch.Queue(batchItem{
+						action: "addResource",
+						query:  query,
+						uid:    resource.UID,
+						args:   params,
+					})
+					if queueErr != nil {
+						klog.Warningf("Error queuing resources to add. Error: %+v", queueErr)
+						// TODO: return queueErr
+					}
+					syncResponse.TotalAdded++
+				}
+				count++
+			}
+			return count, nil
+		}
+	}
+
+	return count, nil
+}
+
+func decodeAddEdges(body []byte, key string) ([]model.Edge, error) {
+	dest := make([]model.Edge, 0)
+	dec := json.NewDecoder(bytes.NewReader(body))
+
+	// read opening {
+	if _, err := dec.Token(); err != nil {
+		return dest, fmt.Errorf("error decoding SyncEvent token: %v", err)
+	}
+	for {
+		// read tokens until we ge to addEdges
+		field, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if field == key {
+			// read opening [
+			if _, err := dec.Token(); err != nil {
+				fmt.Println("err here: ", err.Error())
+			}
+			for dec.More() {
+				var edge model.Edge
+				if err = dec.Decode(&edge); err != nil {
+					return dest, fmt.Errorf("error decoding edge from request: %v", err)
+				}
+				dest = append(dest, edge)
+			}
+			return dest, nil
+		}
+	}
+	return dest, nil
+}
+
 // Reset Resources.
-//  1. Create a map of incoming resources.
-//  2. Query and iterate existing resources for the cluster.
-//  3. For each existing resource:
-//     - UPDATE if doesn't match the incoming resource.
-//     - DELETE if not found in the incoming resource.
-//  4. INSERT incoming resources not found in the existing resources.
-func (dao *DAO) resetResources(ctx context.Context, resources []model.Resource, clusterName string,
-	syncResponse *model.SyncResponse) error {
+//  1. Delete existing resources for cluster
+//  2. Delete existing edges for cluster
+//  3. Iterate over request []byte and insert resource into database
+func (dao *DAO) resetResources(ctx context.Context, clusterName string,
+	syncResponse *model.SyncResponse, body []byte) error {
 	timer := time.Now()
 
 	batch := NewBatchWithRetry(ctx, dao, syncResponse)
 
-	incomingResMap := make(map[string]*model.Resource)
-	for i, resource := range resources {
-		incomingResMap[resource.UID] = &resources[i]
-	}
-	resourcesToDelete := make([]interface{}, 0)
-	resourcesToUpdate := make([]*model.Resource, 0)
-
-	// Get existing resources (UID and data) for the cluster.
+	// Delete existing resources (UID and data) for the cluster.
 	query, params, err := useGoqu(
-		"SELECT uid, data FROM search.resources WHERE cluster=$1 AND uid!='cluster__$1'",
+		"DELETE FROM search.resources WHERE cluster=$1 AND uid!='cluster__$1'",
 		[]interface{}{clusterName})
 	if err == nil {
-		existingRows, err := dao.pool.Query(ctx, query, params...)
+		_, err = dao.pool.Query(ctx, query, params...)
 		if err != nil {
-			klog.Warningf("Error getting existing resource uids for cluster %12s. Error: %+v", clusterName, err)
+			klog.Warningf("Error deleting existing resources for cluster %12s. Error: %+v", clusterName, err)
+			return err
 		}
-		for existingRows.Next() {
-			var id, data string
-			err := existingRows.Scan(&id, &data)
-			if err != nil {
-				klog.Warningf("Error scanning existing resource row. Error: %+v", err)
-				continue
-			}
+	}
 
-			props := make(map[string]interface{})
-			jsonErr := json.Unmarshal([]byte(data), &props)
-			if jsonErr != nil {
-				klog.Warningf("Error unmarshalling existing resource data. Error: %+v", err)
-			}
-
-			incomingResource, exists := incomingResMap[id]
-			if !exists {
-				// Resource needs to be deleted.
-				resourcesToDelete = append(resourcesToDelete, id)
-			} else if !reflect.DeepEqual(incomingResource.Properties, props) {
-				// Resource needs to be updated.
-				resourcesToUpdate = append(resourcesToUpdate, incomingResource)
-				delete(incomingResMap, id)
-			} else {
-				// Resource exists and doesn't need to be updated.
-				delete(incomingResMap, id)
-			}
+	// Delete existing edges for the cluster
+	query, params, err = useGoqu(
+		"DELETE FROM search.edges WHERE cluster=$1 AND edgetype!='intercluster'",
+		[]interface{}{clusterName})
+	if err == nil {
+		_, err = dao.pool.Query(ctx, query, params...)
+		if err != nil {
+			klog.Warningf("Error deleting existing edges for cluster %12s. Error: %+v", clusterName, err)
+			return err
 		}
-		existingRows.Close()
 	}
 	metrics.LogStepDuration(&timer, clusterName, "QUERY existing resources.")
 
-	// INSERT resources that weren't found in the database.
-	for uid, resource := range incomingResMap {
-		data, _ := json.Marshal(resource.Properties)
-		query, params, err := useGoqu(
-			"INSERT into search.resources values($1,$2,$3) ON CONFLICT (uid) DO NOTHING",
-			[]interface{}{uid, clusterName, string(data)})
-		if err == nil {
-			queueErr := batch.Queue(batchItem{
-				action: "addResource",
-				query:  query,
-				uid:    uid,
-				args:   params,
-			})
-			if queueErr != nil {
-				klog.Warningf("Error queuing resources to add. Error: %+v", queueErr)
-				return queueErr
-			}
-			syncResponse.TotalAdded++
-		}
+	// Insert new resources into the cluster
+	countResources, err := decodeAddResources(body, "addResources", clusterName, batch, syncResponse)
+	if err != nil {
+		return err
 	}
+	metrics.RequestSize.Observe(float64(countResources))
 
-	// UPDATE resources that have changed.
-	for _, resource := range resourcesToUpdate {
-		data, _ := json.Marshal(resource.Properties)
-		query, params, err := useGoqu(
-			"UPDATE search.resources SET data=$2 WHERE uid=$1",
-			[]interface{}{resource.UID, string(data)})
-		if err == nil {
-			queueErr := batch.Queue(batchItem{
-				action: "updateResource",
-				query:  query,
-				uid:    resource.UID,
-				args:   params,
-			})
-			if queueErr != nil {
-				klog.Warningf("Error queuing resources to update. Error: %+v", queueErr)
-				return queueErr
-			}
-			syncResponse.TotalUpdated++
-		}
-	}
-
-	// DELETE resources that no longer exist and their edges.
-	if len(resourcesToDelete) > 0 {
-		query, params, err := useGoqu(
-			"DELETE from search.resources WHERE uid IN ($1)",
-			resourcesToDelete)
-		if err == nil {
-			queueErr := batch.Queue(batchItem{
-				action: "deleteResource",
-				query:  query,
-				uid:    fmt.Sprintf("%s", resourcesToDelete),
-				args:   params,
-			})
-			if queueErr != nil {
-				klog.Warningf("Error queuing resources for deletion. Error: %+v", queueErr)
-			}
-			syncResponse.TotalDeleted += len(resourcesToDelete)
-		}
-
-		// DELETE edges that point to deleted resources.
-		query, _, err = useGoqu(
-			"DELETE from search.edges WHERE sourceid IN ($1) OR destid IN ($1)",
-			resourcesToDelete)
-		if err == nil {
-			queueErr := batch.Queue(batchItem{
-				action: "deleteEdge",
-				query:  query,
-				uid:    fmt.Sprintf("%s", resourcesToDelete),
-				args:   params,
-			})
-			if queueErr != nil {
-				klog.Warningf("Error queuing edges for deletion. Error: %+v", queueErr)
-			}
-		}
-	}
 	batch.flush()
 	batch.wg.Wait()
-	syncResponse.TotalAdded = len(incomingResMap)
-	syncResponse.TotalDeleted = len(resourcesToDelete)
-	syncResponse.TotalUpdated = len(resourcesToUpdate)
-	metrics.LogStepDuration(&timer, clusterName,
-		fmt.Sprintf("Reset resources stats: UNCHANGED [%d] INSERT [%d] UPDATE [%d] DELETE [%d]",
-			len(resources)-len(incomingResMap)-len(resourcesToUpdate),
-			syncResponse.TotalAdded, syncResponse.TotalUpdated, syncResponse.TotalDeleted))
+	syncResponse.TotalAdded = countResources
+	// TODO: ensure we have all stats
+	//syncResponse.TotalDeleted = len(resourcesToDelete)
+	//syncResponse.TotalUpdated = len(resourcesToUpdate)
+	//metrics.LogStepDuration(&timer, clusterName,
+	//	fmt.Sprintf("Reset resources stats: UNCHANGED [%d] INSERT [%d] UPDATE [%d] DELETE [%d]",
+	//		countResources-len(incomingResMap)-len(resourcesToUpdate),
+	//		syncResponse.TotalAdded, syncResponse.TotalUpdated, syncResponse.TotalDeleted))
 
 	return batch.connError
 }
@@ -193,8 +184,8 @@ func (dao *DAO) resetResources(ctx context.Context, resources []model.Resource, 
 //  1. Get existing edges for the cluster. Excluding intercluster edges.
 //  2. For each incoming edge, INSERT if it doesn't exist.
 //  3. Delete any existing edges that aren't in the incoming sync event.
-func (dao *DAO) resetEdges(ctx context.Context, edges []model.Edge, clusterName string,
-	syncResponse *model.SyncResponse) error {
+func (dao *DAO) resetEdges(ctx context.Context, clusterName string,
+	syncResponse *model.SyncResponse, body []byte) error {
 	timer := time.Now()
 
 	batch := NewBatchWithRetry(ctx, dao, syncResponse)
@@ -225,14 +216,13 @@ func (dao *DAO) resetEdges(ctx context.Context, edges []model.Edge, clusterName 
 	}
 	metrics.LogStepDuration(&timer, clusterName, "Resync QUERY existing edges")
 
-	// Now compare existing edges with the new edges.
+	edges, err := decodeAddEdges(body, "addEdges")
+	if err != nil {
+		klog.Errorf("Error decoding edges: %v", err)
+		return err
+	}
 	for _, edge := range edges {
-		// If the edge already exists, do nothing.
-		if _, ok := existingEdgesMap[edge.SourceUID+edge.EdgeType+edge.DestUID]; ok {
-			delete(existingEdgesMap, edge.SourceUID+edge.EdgeType+edge.DestUID)
-			continue
-		}
-		// If the edge doesn't exist, add it.
+		// add edges
 		query, params, err := useGoqu(
 			"INSERT into search.edges values($1,$2,$3,$4,$5,$6) ON CONFLICT (sourceid, destid, edgetype) DO NOTHING",
 			[]interface{}{edge.SourceUID, edge.SourceKind, edge.DestUID, edge.DestKind, edge.EdgeType, clusterName})
@@ -248,26 +238,6 @@ func (dao *DAO) resetEdges(ctx context.Context, edges []model.Edge, clusterName 
 				return queueErr
 			}
 			syncResponse.TotalEdgesAdded++
-		}
-	}
-
-	// Delete existing edges that are not in the new sync event.
-	for _, edge := range existingEdgesMap {
-		query, params, err := useGoqu(
-			"DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3",
-			[]interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType})
-		if err == nil {
-			queueErr = batch.Queue(batchItem{
-				action: "deleteEdge",
-				query:  query,
-				uid:    edge.SourceUID,
-				args:   params,
-			})
-			if queueErr != nil {
-				klog.Warningf("Error queuing edges. Error: %+v", queueErr)
-				return queueErr
-			}
-			syncResponse.TotalEdgesDeleted++
 		}
 	}
 

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -4,8 +4,8 @@ package database
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"testing"
 
@@ -26,15 +26,15 @@ func Test_ResyncData(t *testing.T) {
 
 	// Prepare Request data.
 	data, _ := os.Open("./mocks/simple.json")
+	dataBytes, _ := io.ReadAll(data)
 	var syncEvent model.SyncEvent
-	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
 	// Supress console output to prevent log messages from polluting test output.
 	defer testutils.SupressConsoleOutput()()
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	err := dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.ResyncData(context.Background(), syncEvent, "test-cluster", response, dataBytes)
 
 	assert.Nil(t, err)
 }
@@ -51,15 +51,15 @@ func Test_ResyncData_errors(t *testing.T) {
 
 	// Prepare Request data.
 	data, _ := os.Open("./mocks/simple.json")
+	dataBytes, _ := io.ReadAll(data)
 	var syncEvent model.SyncEvent
-	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
 	// Supress console output to prevent log messages from polluting test output.
 	defer testutils.SupressConsoleOutput()()
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	err := dao.ResyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.ResyncData(context.Background(), syncEvent, "test-cluster", response, dataBytes)
 
 	assert.NotNil(t, err)
 }

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"testing"
 
@@ -25,12 +26,13 @@ func Test_SyncData(t *testing.T) {
 
 	// Prepare Request data
 	data, _ := os.Open("./mocks/simple.json")
+	dataBytes, _ := io.ReadAll(data)
 	var syncEvent model.SyncEvent
 	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
 	// Execute test
 	response := &model.SyncResponse{}
-	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response, dataBytes)
 
 	// Assert
 	assert.Nil(t, err)
@@ -55,6 +57,7 @@ func Test_Sync_With_Exec_Errors(t *testing.T) {
 
 	// Prepare Request data
 	data, _ := os.Open("./mocks/simple.json")
+	dataBytes, _ := io.ReadAll(data)
 	var syncEvent model.SyncEvent
 	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
@@ -63,7 +66,7 @@ func Test_Sync_With_Exec_Errors(t *testing.T) {
 
 	// Execute test
 	response := &model.SyncResponse{}
-	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response, dataBytes)
 
 	// Assert
 	assert.Nil(t, err)
@@ -87,6 +90,7 @@ func Test_Sync_With_OnClose_Errors(t *testing.T) {
 
 	// Prepare Request data
 	data, _ := os.Open("./mocks/simple.json")
+	dataBytes, _ := io.ReadAll(data)
 	var syncEvent model.SyncEvent
 	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
 
@@ -95,7 +99,7 @@ func Test_Sync_With_OnClose_Errors(t *testing.T) {
 
 	// Execute test
 	response := &model.SyncResponse{}
-	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response, dataBytes)
 
 	// Assert
 	assert.NotNil(t, err)


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-16129

### Description of changes
- For cluster sync/resync requests: store request body in []byte. Decode if request has `clearAll` true or false to determine if full sync/resync. If sync -> we decode entire request as normal; not concerned with memory spikes from these smaller requests. If resync -> delete all resources and edges for cluster sending the resync request. Then for each resource/edge decoded from [] byte request body, we add the insert query into pool. We observe memory utilization dropped from ~230 MB -> ~120 MB.