### PR TITLE
ACM-16129 cluster resync request counter metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,6 +32,11 @@ var (
 		Buckets: []float64{50, 100, 200, 500, 5000, 10000, 25000, 50000, 100000, 200000},
 	})
 
+	ResyncCount = promauto.With(PromRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "search_indexer_cluster_resync_request_count",
+		Help: "Total cluster resync requests received by the search indexer (from managed clusters).",
+	}, []string{"cluster_resync_request"})
+
 	// FUTURE: The summary metric could combine RequestCount and RequestDuration into a single metric.
 	// RequestSummary = promauto.With(PromRegistry).NewSummaryVec(prometheus.SummaryOpts{
 	// 	Name: "search_indexer_requests_summary",

--- a/pkg/server/syncHandler.go
+++ b/pkg/server/syncHandler.go
@@ -47,8 +47,10 @@ func (s *ServerConfig) SyncResources(w http.ResponseWriter, r *http.Request) {
 	// 1. ReSync [ClearAll=true]  - It has the complete current state. It must overwrite any previous state.
 	// 2. Sync   [ClearAll=false] - This is the delta changes from the previous state.
 	if syncEvent.ClearAll {
+		metrics.ResyncCount.WithLabelValues("true").Inc()
 		err = s.Dao.ResyncData(r.Context(), syncEvent, clusterName, syncResponse)
 	} else {
+		metrics.ResyncCount.WithLabelValues("false").Inc()
 		err = s.Dao.SyncData(r.Context(), syncEvent, clusterName, syncResponse)
 	}
 	if err != nil {


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-16129

### Description of changes
- Added search_indexer_cluster_resync_request_count counter metric so we can track whether requests are a full cluster resync or not. Intended to find the correlation between resource utilization and large full cluster resync requests sent to the search-indexer.
