### PR TITLE
ACM-13201: Disable pgcpool statement cache to reduce memory usage

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,9 +56,9 @@ func new() *Config {
 		DBHost:      getEnv("DB_HOST", "localhost"),
 		// Postgres has 100 conns by default. Using 10 allows scaling indexer and api.
 		DBMaxConns:          getEnvAsInt32("DB_MAX_CONNS", int32(10)),          // 10 - Overrides pgxpool default
-		DBMaxConnLifeJitter: getEnvAsInt("DB_MAX_CONN_LIFE_JITTER", 2*60*1000), // 2 min - Overrides pgxpool default
-		DBMaxConnIdleTime:   getEnvAsInt("DB_MAX_CONN_IDLE_TIME", 30*60*1000),  // 30 min - Default for pgxpool.Config
-		DBMaxConnLifeTime:   getEnvAsInt("DB_MAX_CONN_LIFE_TIME", 60*60*1000),  // 60 min - Default for pgxpool.Config
+		DBMaxConnIdleTime:   getEnvAsInt("DB_MAX_CONN_IDLE_TIME", 5*60*1000),   // 5 min, Overrides pgxpool default (30)
+		DBMaxConnLifeJitter: getEnvAsInt("DB_MAX_CONN_LIFE_JITTER", 2*60*1000), // 2 min, Overrides pgxpool default
+		DBMaxConnLifeTime:   getEnvAsInt("DB_MAX_CONN_LIFE_TIME", 10*60*1000),  // 10 min, Overrides pgxpool default(60)
 		DBMinConns:          getEnvAsInt32("DB_MIN_CONNS", int32(2)),           // 2 - Overrides pgxpool default
 		DBName:              getEnv("DB_NAME", ""),
 		DBPass:              getEnv("DB_PASS", ""),

--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -80,8 +80,9 @@ func initializePool() pgxpoolmock.PgxPool {
 	if configErr != nil {
 		klog.Fatal("Error parsing database connection configuration. ", configErr)
 	}
-	config.AfterConnect = afterConnect   // Checks new connection health before using it.
-	config.BeforeAcquire = beforeAcquire // Checks idle connection health before using it.
+	config.AfterConnect = afterConnect          // Checks new connection health before using it.
+	config.BeforeAcquire = beforeAcquire        // Checks idle connection health before using it.
+	config.ConnConfig.BuildStatementCache = nil // Disable statement cache to reduce connection memory usage.
 	// Add jitter to prevent all connections from being closed at same time.
 	config.MaxConnLifetimeJitter = time.Duration(cfg.DBMaxConnLifeJitter) * time.Millisecond
 	config.MaxConns = cfg.DBMaxConns


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-13201

### Description of changes
- Disables the pgxpool statement cache. This disables the use of prepared statements which consume significant amount of memory in postgres.
- More information: https://aws.amazon.com/blogs/database/resources-consumed-by-idle-postgresql-connections/
