### PR TITLE
ACM-13201: Reduce postgres connection lifetime

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,16 +18,16 @@ const COMPONENT_VERSION = "2.13.0"
 var DEVELOPMENT_MODE = false // Do not change this. See config_development.go to enable.
 var Cfg = new()
 
-// Struct to hold our configuratioin
+// Struct to hold our configuration
 type Config struct {
-	DBBatchSize         int // Batch size used to write to DB. Default: 500
+	DBBatchSize         int // Batch size used to write to DB. Default: 2500
 	DBHealthCkeckPeriod int // Overrides pgxpool.Config{ HealthCheckPeriod } Default: 1 min
 	DBHost              string
-	DBMinConns          int32 // Overrides pgxpool.Config{ MinConns } Default: 0
-	DBMaxConns          int32 // Overrides pgxpool.Config{ MaxConns } Default: 20
-	DBMaxConnIdleTime   int   // Overrides pgxpool.Config{ MaxConnIdleTime } Default: 30 min
-	DBMaxConnLifeTime   int   // Overrides pgxpool.Config{ MaxConnLifetime } Default: 60 min
-	DBMaxConnLifeJitter int   // Overrides pgxpool.Config{ MaxConnLifetimeJitter } Default: 2 min
+	DBMinConns          int32 // Overrides pgxpool.Config{ MinConns } Default: 2
+	DBMaxConns          int32 // Overrides pgxpool.Config{ MaxConns } Default: 10
+	DBMaxConnIdleTime   int   // Overrides pgxpool.Config{ MaxConnIdleTime } Default: 5 min
+	DBMaxConnLifeTime   int   // Overrides pgxpool.Config{ MaxConnLifetime } Default: 5 min
+	DBMaxConnLifeJitter int   // Overrides pgxpool.Config{ MaxConnLifetimeJitter } Default: 1 min
 	DBName              string
 	DBPass              string
 	DBPort              int
@@ -55,11 +55,11 @@ func new() *Config {
 		DBBatchSize: getEnvAsInt("DB_BATCH_SIZE", 2500),
 		DBHost:      getEnv("DB_HOST", "localhost"),
 		// Postgres has 100 conns by default. Using 10 allows scaling indexer and api.
-		DBMaxConns:          getEnvAsInt32("DB_MAX_CONNS", int32(10)),          // 10 - Overrides pgxpool default
-		DBMaxConnLifeJitter: getEnvAsInt("DB_MAX_CONN_LIFE_JITTER", 2*60*1000), // 2 min - Overrides pgxpool default
-		DBMaxConnIdleTime:   getEnvAsInt("DB_MAX_CONN_IDLE_TIME", 30*60*1000),  // 30 min - Default for pgxpool.Config
-		DBMaxConnLifeTime:   getEnvAsInt("DB_MAX_CONN_LIFE_TIME", 60*60*1000),  // 60 min - Default for pgxpool.Config
-		DBMinConns:          getEnvAsInt32("DB_MIN_CONNS", int32(2)),           // 2 - Overrides pgxpool default
+		DBMaxConns:          getEnvAsInt32("DB_MAX_CONNS", int32(10)),          // 10     Overrides pgxpool default (4)
+		DBMaxConnIdleTime:   getEnvAsInt("DB_MAX_CONN_IDLE_TIME", 5*60*1000),   // 5 min, Overrides pgxpool default (30)
+		DBMaxConnLifeJitter: getEnvAsInt("DB_MAX_CONN_LIFE_JITTER", 1*60*1000), // 1 min, Overrides pgxpool default
+		DBMaxConnLifeTime:   getEnvAsInt("DB_MAX_CONN_LIFE_TIME", 10*60*1000),  // 5 min, Overrides pgxpool default (60)
+		DBMinConns:          getEnvAsInt32("DB_MIN_CONNS", int32(2)),           // 2      Overrides pgxpool default (0)
 		DBName:              getEnv("DB_NAME", ""),
 		DBPass:              getEnv("DB_PASS", ""),
 		DBPort:              getEnvAsInt("DB_PORT", 5432),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,7 +58,7 @@ func new() *Config {
 		DBMaxConns:          getEnvAsInt32("DB_MAX_CONNS", int32(10)),          // 10     Overrides pgxpool default (4)
 		DBMaxConnIdleTime:   getEnvAsInt("DB_MAX_CONN_IDLE_TIME", 5*60*1000),   // 5 min, Overrides pgxpool default (30)
 		DBMaxConnLifeJitter: getEnvAsInt("DB_MAX_CONN_LIFE_JITTER", 1*60*1000), // 1 min, Overrides pgxpool default
-		DBMaxConnLifeTime:   getEnvAsInt("DB_MAX_CONN_LIFE_TIME", 10*60*1000),  // 5 min, Overrides pgxpool default (60)
+		DBMaxConnLifeTime:   getEnvAsInt("DB_MAX_CONN_LIFE_TIME", 5*60*1000),   // 5 min, Overrides pgxpool default (60)
 		DBMinConns:          getEnvAsInt32("DB_MIN_CONNS", int32(2)),           // 2      Overrides pgxpool default (0)
 		DBName:              getEnv("DB_NAME", ""),
 		DBPass:              getEnv("DB_PASS", ""),


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-13201

### Description of changes
- Reduce the Postgres connection lifetime to **5 minutes**.
- This helps release memory used by the Postgres pod for the connection caches.

Note: This **doesn't disable the statement cache** to avoid other performance issues.
