### PR TITLE
[release-2.13] Fix incorrect label in Dockerfile.rhtap

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -30,6 +30,6 @@ LABEL com.redhat.component="acm-search-indexer-container" \
       org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
       org.label-schema.schema-version="1.0" \
       summary="Search indexer service" \
-      io.k8s.display-name="Search collector" \
+      io.k8s.display-name="Search indexer" \
       io.k8s.description="Search indexer service" \
       io.openshift.tags="data,images"


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Fix incorrect image label merged with #362 
