### PR TITLE
[release-2.10] fix sast-snyk-check missing image-digest and image-url

### DIFF
--- a/.tekton/search-indexer-acm-210-pull-request.yaml
+++ b/.tekton/search-indexer-acm-210-pull-request.yaml
@@ -316,6 +316,10 @@ spec:
           value: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.3@sha256:9fa6975ec81dfa45b3ba383a8276dfd4b478ae5265a595600d91220e1d49d6bb
         - name: kind
           value: task
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
### Description of changes
- cherry-pick of https://github.com/stolostron/search-indexer/pull/410/files to fix konflux failures