### PR TITLE
ACM-20720 handle db state after local-cluster rename

### DIFF
--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -213,7 +213,6 @@ func (dao *DAO) upsertResources(ctx context.Context, resyncBody []byte, clusterN
 				}
 				incomingUIDs = append(incomingUIDs, uid)
 			}
-			//err = dao.checkHubClusterRename(ctx, resource, clusterName)
 			return incomingUIDs, resource, err
 		}
 	}

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -233,7 +233,7 @@ func (dao *DAO) hubClusterCleanUpWithRetry(ctx context.Context, requestCluster s
 			klog.Errorf("Error handling old hub cluster check and cleanup: %s. Will retry in %s\n", err.Error(), timeToSleep)
 			time.Sleep(timeToSleep)
 		} else {
-			klog.Info("Successfully completed check and handling of old hub clusters.")
+			klog.V(1).Info("Successfully completed check and handling of old hub clusters.")
 			break
 		}
 	}

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stolostron/search-indexer/pkg/config"
 	"io"
 	"math"
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/stolostron/search-indexer/pkg/config"
 	"github.com/stolostron/search-indexer/pkg/metrics"
 	"github.com/stolostron/search-indexer/pkg/model"
 	"k8s.io/klog/v2"
@@ -220,8 +220,7 @@ func (dao *DAO) upsertResources(ctx context.Context, resyncBody []byte, clusterN
 }
 
 // hubClusterCleanUpWithRetry takes the known hub cluster name from the latest resync request and deletes all other
-//
-//	old hub cluster resources and edges, if any. Retries until success to ensure outdated resources are deleted.
+// old hub cluster resources and edges, if any. Retries until success to ensure outdated resources are deleted.
 func (dao *DAO) hubClusterCleanUpWithRetry(ctx context.Context, requestCluster string) {
 	cfg := config.Cfg
 	retry := 0

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -219,6 +219,9 @@ func (dao *DAO) upsertResources(ctx context.Context, resyncBody []byte, clusterN
 	return incomingUIDs, resource, nil
 }
 
+// hubClusterCleanUpWithRetry takes the known hub cluster name from the latest resync request and deletes all other
+//
+//	old hub cluster resources and edges, if any. Retries until success to ensure outdated resources are deleted.
 func (dao *DAO) hubClusterCleanUpWithRetry(ctx context.Context, requestCluster string) {
 	cfg := config.Cfg
 	retry := 0
@@ -231,6 +234,7 @@ func (dao *DAO) hubClusterCleanUpWithRetry(ctx context.Context, requestCluster s
 			klog.Errorf("Error handling old hub cluster check and cleanup: %s. Will retry in %s\n", err.Error(), timeToSleep)
 			time.Sleep(timeToSleep)
 		} else {
+			klog.Info("Successfully completed check and handling of old hub clusters.")
 			break
 		}
 	}

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -5,6 +5,9 @@ package database
 import (
 	"context"
 	"errors"
+	"github.com/driftprogramming/pgxpoolmock"
+	"github.com/jackc/pgconn"
+	"github.com/pashagolub/pgxmock"
 	"io"
 	"os"
 	"testing"
@@ -60,4 +63,86 @@ func Test_ResyncData_errors(t *testing.T) {
 	err := dao.ResyncData(context.Background(), "test-cluster", response, dataBytes)
 
 	assert.NotNil(t, err)
+}
+
+func Test_CheckHubClusterRenameWithoutChange(t *testing.T) {
+	// Prepare a mock DAO instance
+	dao, mockPool := buildMockDAO(t)
+
+	// Mock Postgres state with existing hub cluster test-cluster
+	testutils.MockDatabaseState(mockPool)
+
+	// test-cluster is the only cluster to exist in the database, no cleanup should happen
+	err := dao.checkHubClusterRename(context.Background(), "test-cluster")
+
+	// no further mock queries and old hub cluster cleanup was required
+	assert.Nil(t, err)
+}
+
+func Test_CheckHubClusterRenameWithChange(t *testing.T) {
+	// Prepare a mock DAO instance
+	dao, mockPool := buildMockDAO(t)
+
+	// Mock Postgres state with existing hub cluster test-cluster
+	testutils.MockDatabaseState(mockPool)
+
+	// test-cluster gets cleaned up from search.resources
+	mockPool.EXPECT().Exec(gomock.Any(),
+		`DELETE FROM "search"."resources" WHERE ("cluster" = 'test-cluster')`,
+		[]interface{}{}).Return(pgxmock.NewResult("DELETE", 1), nil)
+
+	// test-cluster gets cleaned up from search.edges
+	mockPool.EXPECT().Exec(gomock.Any(),
+		`DELETE FROM "search"."edges" WHERE ("cluster" = 'test-cluster')`,
+		[]interface{}{}).Return(pgxmock.NewResult("DELETE", 1), nil)
+
+	// test-cluster should get cleaned up when we call this with the new hub cluster new-cluster
+	err := dao.checkHubClusterRename(context.Background(), "new-cluster")
+
+	assert.Nil(t, err)
+}
+
+func Test_HubClusterCleanupWithoutChangeWithRetry(t *testing.T) {
+	// Prepare a mock DAO instance
+	dao, mockPool := buildMockDAO(t)
+
+	// Mock Postgres state with existing hub cluster test-cluster
+	testutils.MockDatabaseState(mockPool)
+
+	// Mock a failed deletion of search.resources where it succeeds on second attempt
+	retry := 0
+	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq(
+		`DELETE FROM "search"."resources" WHERE ("cluster" = 'test-cluster')`),
+		[]interface{}{}).Times(2).DoAndReturn(func(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+		if retry == 0 {
+			retry++
+			return nil, errors.New("error deleting old hub cluster")
+		} else {
+			retry = 0
+			return pgconn.CommandTag("DELETE 1"), nil
+		}
+	})
+
+	// Mock a failed deletion of search.edges where it succeeds on second attempt
+	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq(
+		`DELETE FROM "search"."edges" WHERE ("cluster" = 'test-cluster')`),
+		[]interface{}{}).Times(2).DoAndReturn(func(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+		if retry == 0 {
+			retry++
+			return nil, errors.New("error deleting old hub cluster")
+		} else {
+			return pgconn.CommandTag("DELETE 1"), nil
+		}
+	})
+
+	// Mock selecting the distinct hub cluster names 4 times; once per attempt
+	cluster := []string{"cluster"}
+	clusterRows := pgxpoolmock.NewRows(cluster).AddRow("test-cluster").ToPgxRows()
+	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
+		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE "data"?'_hubClusterResource'`),
+		[]interface{}{}).Return(clusterRows, nil).Times(4)
+
+	// test-cluster should get cleaned up when we call this with the new hub cluster new-cluster
+	dao.hubClusterCleanUpWithRetry(context.Background(), "new-cluster")
+
 }

--- a/pkg/testutils/mockDatabaseState.go
+++ b/pkg/testutils/mockDatabaseState.go
@@ -12,6 +12,8 @@ func MockDatabaseState(mockPool *pgxpoolmock.MockPgxPool) {
 	resourceRows := pgxpoolmock.NewRows(columns).AddRow("uid-123", `{"kind: "mock"}`).ToPgxRows()
 	edgeColumns := []string{"sourceId", "edgeType", "destId"}
 	edgeRows := pgxpoolmock.NewRows(edgeColumns).AddRow("sourceId1", "edgeType1", "destId1").ToPgxRows()
+	cluster := []string{"cluster"}
+	clusterRows := pgxpoolmock.NewRows(cluster).AddRow("test-cluster").ToPgxRows()
 
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
 		`SELECT "uid", "data" FROM "search"."resources" WHERE (("cluster" = $1) AND ("uid" != $2))`),
@@ -19,4 +21,7 @@ func MockDatabaseState(mockPool *pgxpoolmock.MockPgxPool) {
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
 		`SELECT "sourceid", "edgetype", "destid" FROM "search"."edges" WHERE (("edgetype" != $1) AND ("cluster" = $2))`),
 		[]interface{}{"interCluster", "test-cluster"}).Return(edgeRows, nil)
+	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
+		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE "data"?'_hubClusterResource'`),
+		[]interface{}{}).Return(clusterRows, nil)
 }


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-20720

### Description of changes
- Handles the DB state when local-cluster gets renamed by:

1. checking if cluster resync request contains a hub cluster resource by checking properties for _hubClusterResource
2. queries for all distinct cluster names
3. if clusters exist that don't match the incoming hubClusterResource cluster, delete them