### PR TITLE
Fix accidental data accumulation

### DIFF
--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -190,6 +190,7 @@ func (dao *DAO) upsertResources(ctx context.Context, resyncBody []byte, clusterN
 				return incomingUIDs, resource, fmt.Errorf("error reading addResources opening token: %v", err)
 			}
 			for dec.More() {
+				resource = model.Resource{}
 				if err = dec.Decode(&resource); err != nil {
 					return incomingUIDs, resource, fmt.Errorf("error decoding resource from request: %v", err)
 				}


### PR DESCRIPTION
Previously, the `upsertResources` function could repeatedly decode items into the same resource, and then insert that updated resource into the database. Fields from the new item would overwrite existing fields in the resource, but it would not remove the fields that were not set in the new item, causing incorrect data to accumulate in some resources.

Now the resource is reset before decoding.

Refs:
 - https://issues.redhat.com/browse/ACM-21047

<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-21047

### Description of changes
- Fix accidental data accumulation in resources