### PR TITLE
resync request hub cluster rename check incorrect sql

### DIFF
--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -280,20 +280,20 @@ func (dao *DAO) checkHubClusterRename(ctx context.Context, requestCluster string
 
 	// if old hub cluster name(s) != new hub cluster name, delete all old hub cluster(s) resources and edges
 	for _, c := range clustersToDelete {
-		if err = dao.deleteOldHubClusterFromDBTable(ctx, c, "resources"); err != nil {
+		if err = dao.deleteOldHubClusterFromDBTable(ctx, c, "resources", requestCluster); err != nil {
 			return err
 		}
-		if err = dao.deleteOldHubClusterFromDBTable(ctx, c, "edges"); err != nil {
+		if err = dao.deleteOldHubClusterFromDBTable(ctx, c, "edges", requestCluster); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (dao *DAO) deleteOldHubClusterFromDBTable(ctx context.Context, cluster string, table string) error {
+func (dao *DAO) deleteOldHubClusterFromDBTable(ctx context.Context, oldHubCluster string, table string, newHubCluster string) error {
 	// DELETE FROM search.? WHERE cluster = ?
 	sql, args, err := goqu.From(goqu.S("search").Table(table)).
-		Delete().Where(goqu.C("cluster").Eq(cluster)).ToSQL()
+		Delete().Where(goqu.C("cluster").Eq(oldHubCluster)).ToSQL()
 	if err != nil {
 		klog.Errorf("Error creating query to delete old hub cluster %s: %s", table, err.Error())
 		return err
@@ -303,7 +303,7 @@ func (dao *DAO) deleteOldHubClusterFromDBTable(ctx context.Context, cluster stri
 		klog.Errorf("Error deleting old hub cluster %s: %s", table, err.Error())
 		return err
 	}
-	klog.Infof("Deleted %d old hub cluster %s", res.RowsAffected(), table)
+	klog.Infof("Deleted %d old hub cluster %s from cluster: %s. New hub cluster is %s", res.RowsAffected(), table, oldHubCluster, newHubCluster)
 
 	return nil
 }

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -249,7 +249,10 @@ func (dao *DAO) checkHubClusterRename(ctx context.Context, requestCluster string
 	sql, args, err := goqu.From(goqu.S("search").Table("resources")).
 		Select("cluster").
 		Distinct().
-		Where(goqu.L("???", goqu.C("data"), goqu.Literal("?"), "_hubClusterResource")).ToSQL()
+		Where(goqu.And(
+			goqu.L("???", goqu.C("data"), goqu.Literal("?"), "_hubClusterResource"),
+			goqu.L("?->>? <> ?", goqu.C("data"), "kind", "Cluster"))).ToSQL()
+	fmt.Println("sql: ", sql)
 	if err != nil {
 		klog.Errorf("Error creating query to check existing hub cluster name")
 		return err

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -252,7 +252,6 @@ func (dao *DAO) checkHubClusterRename(ctx context.Context, requestCluster string
 		Where(goqu.And(
 			goqu.L("???", goqu.C("data"), goqu.Literal("?"), "_hubClusterResource"),
 			goqu.L("?->>? <> ?", goqu.C("data"), "kind", "Cluster"))).ToSQL()
-	fmt.Println("sql: ", sql)
 	if err != nil {
 		klog.Errorf("Error creating query to check existing hub cluster name")
 		return err

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -139,7 +139,7 @@ func Test_HubClusterCleanupWithoutChangeWithRetry(t *testing.T) {
 	cluster := []string{"cluster"}
 	clusterRows := pgxpoolmock.NewRows(cluster).AddRow("test-cluster").ToPgxRows()
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
-		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE "data"?'_hubClusterResource'`),
+		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE ("data"?'_hubClusterResource' AND "data"->>'kind' <> 'Cluster')`),
 		[]interface{}{}).Return(clusterRows, nil).Times(4)
 
 	// test-cluster should get cleaned up when we call this with the new hub cluster new-cluster

--- a/pkg/testutils/mockDatabaseState.go
+++ b/pkg/testutils/mockDatabaseState.go
@@ -22,6 +22,6 @@ func MockDatabaseState(mockPool *pgxpoolmock.MockPgxPool) {
 		`SELECT "sourceid", "edgetype", "destid" FROM "search"."edges" WHERE (("edgetype" != $1) AND ("cluster" = $2))`),
 		[]interface{}{"interCluster", "test-cluster"}).Return(edgeRows, nil)
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
-		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE "data"?'_hubClusterResource'`),
+		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE ("data"?'_hubClusterResource' AND "data"->>'kind' <> 'Cluster')`),
 		[]interface{}{}).Return(clusterRows, nil)
 }


### PR DESCRIPTION
### Description of changes
- Fixed SQL for selecting distinct cluster names on the hub cluster when checking for hub cluster rename. A resource of kind Cluster for each cluster exists on the hub cluster, we missed explicitly exempting that condition in the SQL. This led to each resync request triggering a hub cluster cleanup