### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for search-indexer-acm-214

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -21,7 +21,8 @@ ENTRYPOINT ["/bin/main"]
 LABEL com.redhat.component="acm-search-indexer-container" \
       description="Search indexer service" \      
       maintainer="acm-contact@redhat.com" \
-      name="search-indexer" \
+      name="rhacm2/acm-search-indexer-rhel9" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
       org.label-schema.schema-version="1.0" \
       summary="Search indexer service" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
