### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -5,7 +5,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS bui
 WORKDIR /go/src/github.com/stolostron/search-indexer
 COPY . .
 RUN go mod vendor
-RUN CGO_ENABLED=1 go build -trimpath -o main main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -trimpath -o main main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847

<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-0000

### Description of changes
- Added ...
