### PR TITLE
chore: onboard repository to Fleet Engineering Agentic SDLC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# search-indexer
+
+ACM Search component that receives resource sync events from managed clusters and persists them to PostgreSQL.
+
+For system architecture, data flows, and module layout, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Commands
+
+```bash
+# Run locally (development mode — disables strict TLS validation)
+make setup                          # Generate self-signed TLS cert (required before first run)
+go run -tags development main.go -v=3
+
+# Test
+go test ./... -failfast             # Unit tests
+go test ./... -failfast -v -coverprofile cover.out  # With coverage
+
+# Build
+go build ./...
+docker build -f Dockerfile . -t search-indexer
+podman build -f Dockerfile . -t search-indexer
+
+# Lint (requires golangci-lint v2.4.0 and gosec installed)
+CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
+go mod tidy
+gosec ./...
+
+# Simulate a sync request locally
+curl -k -H "X-Overwrite-State: true" -d "@pkg/server/mocks/clusterA.json" -X POST https://localhost:3010/aggregator/clusters/clusterA/sync
+```
+
+## Required environment variables
+
+The indexer will exit on startup if these are missing:
+
+| Variable | Description |
+|---|---|
+| `DB_NAME` | PostgreSQL database name |
+| `DB_USER` | PostgreSQL user |
+| `DB_PASS` | PostgreSQL password |
+
+Optional overrides (defaults shown): `DB_HOST=localhost`, `DB_PORT=5432`, `AGGREGATOR_ADDRESS=:3010`, `REQUEST_LIMIT=25`, `RESYNC_PERIOD_MS=900000`.
+
+## Non-obvious conventions
+
+- **`-tags development` build tag** enables development mode, which relaxes TLS requirements. Controlled via `pkg/config/config_development.go`, not an env var.
+- **TLS cert required** even for local runs. `make setup` generates a self-signed cert at `sslcert/tls.crt` + `sslcert/tls.key` using `sslcert/req.conf`.
+- **`X-Overwrite-State` header** controls sync type: `true` = full resync (collector sends complete current state); `false` or absent = delta sync. ResyncData decodes the body as a streaming JSON reader to handle large payloads without loading them fully into memory.
+- **Cluster node UID format** is `cluster__<clusterName>` (two underscores). Hub cluster resources carry a `_hubClusterResource` property that triggers cleanup of any old hub cluster data on resync.
+- **Database schema** uses the `search` schema, not the default public schema: `search.resources` and `search.edges`.
+- **Leader election** (`pkg/clustersync`) uses a Kubernetes lease lock named `search-indexer.open-cluster-management.io`. Only the leader runs the ManagedCluster informers.
+- **`make lint`** re-downloads golangci-lint on every run. Run `golangci-lint` directly if it is already installed.
+
+## Personal configuration
+
+Read personal config at the start of any task that needs an assignee, email, or project key.
+Use the tool-aware fallback chain: `~/.config/opencode/user.local.md` (OpenCode),
+`.claude/user.local.md` (Claude Code), or `.cursor/rules/user.local.mdc` (Cursor, already in context).
+If none exist, fall back to agent memory (`user-config`), then placeholders.
+Run `make personalize` to generate all three files (if this repo uses Fleet Engineering tooling).
+
+## Fleet Engineering Skills
+
+All skills are available as slash commands. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,26 +7,14 @@ For system architecture, data flows, and module layout, see [docs/ARCHITECTURE.m
 ## Commands
 
 ```bash
-# Run locally (development mode — disables strict TLS validation)
-make setup                          # Generate self-signed TLS cert (required before first run)
-go run -tags development main.go -v=3
-
-# Test
-go test ./... -failfast             # Unit tests
-go test ./... -failfast -v -coverprofile cover.out  # With coverage
-
-# Build
-go build ./...
-docker build -f Dockerfile . -t search-indexer
-podman build -f Dockerfile . -t search-indexer
-
-# Lint (requires golangci-lint v2.4.0 and gosec installed)
-CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
-go mod tidy
-gosec ./...
-
-# Simulate a sync request locally
-curl -k -H "X-Overwrite-State: true" -d "@pkg/server/mocks/clusterA.json" -X POST https://localhost:3010/aggregator/clusters/clusterA/sync
+make setup          # Generate self-signed TLS cert (required before first run)
+make run            # Run locally in development mode
+make test           # Unit tests
+make coverage       # Unit tests with HTML coverage report
+make docker-build   # Build Docker image
+make podman-build   # Build with Podman
+make lint           # Run golangci-lint + gosec (downloads golangci-lint if not present)
+make test-send      # Simulate a sync request against the local instance
 ```
 
 ## Required environment variables
@@ -49,7 +37,11 @@ Optional overrides (defaults shown): `DB_HOST=localhost`, `DB_PORT=5432`, `AGGRE
 - **Cluster node UID format** is `cluster__<clusterName>` (two underscores). Hub cluster resources carry a `_hubClusterResource` property that triggers cleanup of any old hub cluster data on resync.
 - **Database schema** uses the `search` schema, not the default public schema: `search.resources` and `search.edges`.
 - **Leader election** (`pkg/clustersync`) uses a Kubernetes lease lock named `search-indexer.open-cluster-management.io`. Only the leader runs the ManagedCluster informers.
-- **`make lint`** re-downloads golangci-lint on every run. Run `golangci-lint` directly if it is already installed.
+- **`make lint`** re-downloads golangci-lint on every run if it is not already installed.
+
+## Fleet Engineering Skills
+
+All skills are available as slash commands. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.
 
 ## Personal configuration
 
@@ -58,7 +50,3 @@ Use the tool-aware fallback chain: `~/.config/opencode/user.local.md` (OpenCode)
 `.claude/user.local.md` (Claude Code), or `.cursor/rules/user.local.mdc` (Cursor, already in context).
 If none exist, fall back to agent memory (`user-config`), then placeholders.
 Run `make personalize` to generate all three files (if this repo uses Fleet Engineering tooling).
-
-## Fleet Engineering Skills
-
-All skills are available as slash commands. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# search-indexer Architecture
+
+## Overview
+
+search-indexer is a Go HTTPS service running inside the ACM hub cluster. It is the write path for the ACM Search datastore. Each managed cluster runs a `search-collector` agent that sends sync events to this service; the indexer writes those events to a shared PostgreSQL database that `search-api` reads from.
+
+```
+search-collector (per managed cluster)
+        │  HTTPS POST /aggregator/clusters/{id}/sync
+        ▼
+  search-indexer  ──────────────────────────────► PostgreSQL
+        │                                          search.resources
+        │  (leader only, via Kubernetes informers) search.edges
+        └──────── ManagedCluster / ManagedClusterInfo / ManagedClusterAddOn
+```
+
+## Packages
+
+| Package | Responsibility |
+|---|---|
+| `main` | Bootstrap: init config, create DAO, start clustersync (goroutine) and server (goroutine), wait for SIGINT/SIGTERM |
+| `pkg/config` | All configuration from environment variables. `Cfg` is a package-level singleton. Development mode is a build tag (`-tags development`), not an env var. |
+| `pkg/server` | HTTPS server on `:3010`. Routes: `/liveness`, `/readiness`, `/metrics`, `POST /aggregator/clusters/{id}/sync`. Applies two rate-limiting middlewares. |
+| `pkg/database` | PostgreSQL DAO. Uses `pgxpool` for connection pooling. Operates on `search.resources` and `search.edges`. Batches writes for throughput. |
+| `pkg/clustersync` | Watches `ManagedCluster`, `ManagedClusterInfo`, and `ManagedClusterAddOn` objects and keeps the `Cluster` pseudo-node in PostgreSQL in sync. Requires leader election. |
+| `pkg/model` | Plain Go structs: `Resource`, `Edge`, `SyncEvent`, `SyncResponse`, `SyncError`, `DeleteResourceEvent`. |
+| `pkg/metrics` | Prometheus registry and instrumentation helpers (`PrometheusMiddleware`, `SlowLog`, `LogStepDuration`, `RequestSize`). |
+
+## Key data flows
+
+### Delta sync (`X-Overwrite-State: false`)
+
+1. Collector sends a JSON `SyncEvent` with arrays: `AddResources`, `UpdateResources`, `DeleteResources`, `AddEdges`, `DeleteEdges`.
+2. `server.SyncResources` decodes the full body and calls `database.DAO.SyncData`.
+3. `SyncData` enqueues SQL operations into a `batchWithRetry`, flushes in configurable batch sizes (default 2500), and waits for all batches to complete.
+4. Responds with `SyncResponse` containing per-operation counts and the current total resource/edge counts (for collector-side validation).
+
+### Full resync (`X-Overwrite-State: true`)
+
+1. Collector sends the complete current state (can be very large — 20 MB+ threshold for the large-request limiter).
+2. Body is passed as a raw `[]byte` to `database.DAO.ResyncData`.
+3. `ResyncData` uses a streaming JSON decoder (`json.NewDecoder`) to process `addResources` and `addEdges` without fully buffering the body — avoids memory spikes.
+4. After upserting, it bulk-deletes resources and edges whose UIDs are absent from the incoming set.
+5. On resync from the hub cluster (detected by `_hubClusterResource` property), a background goroutine cleans up stale data from any prior hub cluster name (hub rename handling).
+
+### Cluster node lifecycle (`pkg/clustersync`)
+
+- Leader-elected: only one indexer pod runs the informers at a time.
+- `ManagedCluster` events produce or update a `Cluster` pseudo-node; `ManagedClusterInfo` enriches it (console URL, node count, API endpoint).
+- Both object types write to the same UID (`cluster__<clusterName>`), with `addAdditionalProperties` merging fields from the in-memory cache.
+- `ManagedClusterAddOn` delete events (specifically `search-collector`) trigger deletion of all cluster resources and edges but preserve the cluster node.
+- `ManagedCluster` delete events remove the cluster node plus all resources.
+- On startup, `deleteStaleClusterResources` cross-references the database against the live cluster list and prunes orphans.
+
+## Database schema
+
+Tables are in the `search` schema (not the default `public`):
+
+| Table | Columns | Notes |
+|---|---|---|
+| `search.resources` | `uid TEXT PK`, `cluster TEXT`, `data JSONB` | One row per Kubernetes resource. `data` is a free-form property bag (no fixed schema per kind). |
+| `search.edges` | `sourceid TEXT`, `sourcekind TEXT`, `destid TEXT`, `destkind TEXT`, `edgetype TEXT`, `cluster TEXT` | Composite PK on `(sourceid, destid, edgetype)`. Represents relationships between resources. `interCluster` edges are excluded from per-cluster resync edge diffing. |
+
+## Rate limiting
+
+Two independent semaphore-based middlewares protect the database from overload:
+
+- `requestLimiterMiddleware`: caps total concurrent requests (default 25, `REQUEST_LIMIT`).
+- `largeRequestLimiterMiddleware`: caps concurrent requests larger than 20 MB (default 5, `LARGE_REQUEST_LIMIT`/`LARGE_REQUEST_SIZE`). Requests below the size threshold bypass this limiter.
+
+## TLS
+
+The server requires real certificates even in development. `make setup` generates a self-signed cert into `sslcert/` using `sslcert/req.conf`. The `-tags development` build tag sets `DevelopmentMode=true`, which changes the fatal error on startup TLS failure to a more descriptive message pointing to `./setup.sh`.
+
+## Design decisions
+
+- **No ORM**: Raw SQL via `pgx`/`goqu`. `goqu` is used for parameterized query construction in the resync path (avoids injection; handles IN-clause with slices).
+- **Batch writes over individual statements**: `batchWithRetry` accumulates SQL operations and flushes them via `pgx.Batch` for throughput. Each batch operation tracks its UID for error attribution in `SyncResponse`.
+- **In-memory cluster cache** (`pkg/database/cache.go`): `ReadClustersCache` / `WriteClustersCache` used in `addAdditionalProperties` to merge `ManagedCluster` and `ManagedClusterInfo` fields without a second DB round-trip.
+- **Streaming resync decoder**: Full resync bodies from large clusters can exceed hundreds of MB. The resync path uses `json.NewDecoder` token-by-token to avoid loading the full body into memory.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 search-indexer is a Go HTTPS service running inside the ACM hub cluster. It is the write path for the ACM Search datastore. Each managed cluster runs a `search-collector` agent that sends sync events to this service; the indexer writes those events to a shared PostgreSQL database that `search-api` reads from.
 
-```
+```text
 search-collector (per managed cluster)
         │  HTTPS POST /aggregator/clusters/{id}/sync
         ▼


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with verified `make`-based commands, required env vars, and non-obvious conventions (build tags, TLS cert requirement, sync header semantics, DB schema prefix, leader election)
- Add `docs/ARCHITECTURE.md` covering service overview, package responsibilities, key data flows (delta sync vs. full resync), database schema, rate limiting, and design decisions
- Wire Fleet Engineering skills catalog reference and personal config lookup into `CLAUDE.md`

## Test plan

- [x] Verify `make` commands in `CLAUDE.md` match the `Makefile` targets
- [x] Review `docs/ARCHITECTURE.md` for accuracy against the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup and operation docs for the search-indexer service, including build/test/run commands, environment variables, and developer conventions.
  * Added detailed architecture docs describing service responsibilities, delta and full resync data flows, cluster lifecycle behavior, database schema overview, rate-limiting, TLS/dev notes, and core design decisions.
  * Included guidance for accessing engineering resources and locating personal configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->