### PR TITLE
[release-2.11] ACM-37648 - Update Go to 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: stolostron
-  tag: go1.24-linux
+  tag: go1.26-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/search-indexer
 COPY . .

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /go/src/github.com/stolostron/search-indexer
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ run: ## Run the service locally.
 .PHONY: lint
 lint: ## Run lint and gosec tool.
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.64.6
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
 	go mod tidy
 	gosec ./...

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -9,7 +9,7 @@ build:
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.64.6
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v2.9.0
 	CGO_ENABLED=1 GOGC=25 golangci-lint run --timeout=3m
 	gosec ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // Copyright Contributors to the Open Cluster Management project
 module github.com/stolostron/search-indexer
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/doug-martin/goqu/v9 v9.18.0

--- a/pkg/clustersync/clusterSync_test.go
+++ b/pkg/clustersync/clusterSync_test.go
@@ -229,7 +229,9 @@ func Test_ProcessClusterDeleteOnMC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, nil)
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."edges" WHERE ("cluster" = 'name-foo')`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -265,7 +267,9 @@ func Test_ProcessClusterDeleteOnMCASearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, nil)
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."edges" WHERE ("cluster" = 'name-foo')`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -339,7 +343,9 @@ func Test_DeleteStaleClustersResources(t *testing.T) {
 		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, nil)
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."edges" WHERE ("cluster" = 'name-foo')`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -417,7 +423,9 @@ func Test_DeleteStaleClustersResources_DB_Outage(t *testing.T) {
 		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, fakeErr).Times(1).Return(mockConn, nil).Times(1) // return mock error
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."edges" WHERE ("cluster" = 'name-foo')`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))

--- a/pkg/clustersync/testHelper_test.go
+++ b/pkg/clustersync/testHelper_test.go
@@ -19,7 +19,9 @@ func supressConsoleOutput() func() {
 	os.Stderr = nullFile
 
 	return func() {
-		defer nullFile.Close()
+		defer func(nullFile *os.File) {
+			_ = nullFile.Close()
+		}(nullFile)
 		os.Stderr = stdErr
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,13 +134,13 @@ func getEnvAsInt32(name string, defaultVal int32) int32 {
 // Validate required configuration.
 func (cfg *Config) Validate() error {
 	if cfg.DBName == "" {
-		return errors.New("Required environment DB_NAME is not set.")
+		return errors.New("required environment DB_NAME is not set")
 	}
 	if cfg.DBUser == "" {
-		return errors.New("Required environment DB_USER is not set.")
+		return errors.New("required environment DB_USER is not set")
 	}
 	if cfg.DBPass == "" {
-		return errors.New("Required environment DB_PASS is not set.")
+		return errors.New("required environment DB_PASS is not set")
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,7 @@ func Test_getEnv_default(t *testing.T) {
 
 // Should load string value from environment.
 func Test_getEnv(t *testing.T) {
-	os.Setenv("TEST_VARIABLE", "test-value")
+	_ = os.Setenv("TEST_VARIABLE", "test-value")
 	res := getEnv("TEST_VARIABLE", "default-value")
 
 	if res != "test-value" {
@@ -41,7 +41,7 @@ func Test_getEnvAsInt_default(t *testing.T) {
 
 // Should load int value from environment.
 func Test_getEnvAsInt(t *testing.T) {
-	os.Setenv("TEST_VARIABLE", "99")
+	_ = os.Setenv("TEST_VARIABLE", "99")
 	res := getEnvAsInt("TEST_VARIABLE", 0)
 
 	if res != 99 {
@@ -77,9 +77,9 @@ func Test_PrintConfig(t *testing.T) {
 
 // Should validate that DB_NAME, DB_USER, and DB_PASS are required environment variables.
 func Test_Validate(t *testing.T) {
-	os.Setenv("DB_NAME", "test")
-	os.Setenv("DB_USER", "test")
-	os.Setenv("DB_PASS", "test")
+	_ = os.Setenv("DB_NAME", "test")
+	_ = os.Setenv("DB_USER", "test")
+	_ = os.Setenv("DB_PASS", "test")
 	conf := new()
 
 	result := conf.Validate()
@@ -87,24 +87,24 @@ func Test_Validate(t *testing.T) {
 		t.Errorf("Expected %v Got: %+v", nil, result)
 	}
 
-	os.Setenv("DB_PASS", "")
+	_ = os.Setenv("DB_PASS", "")
 	conf = new()
 	result = conf.Validate()
-	if result.Error() != "Required environment DB_PASS is not set." {
-		t.Errorf("Expected %s Got: %s", "Required environment DB_PASS is not set.", result)
+	if result.Error() != "required environment DB_PASS is not set" {
+		t.Errorf("Expected %s Got: %s", "required environment DB_PASS is not set", result)
 	}
 
-	os.Setenv("DB_USER", "")
+	_ = os.Setenv("DB_USER", "")
 	conf = new()
 	result = conf.Validate()
-	if result.Error() != "Required environment DB_USER is not set." {
-		t.Errorf("Expected %s Got: %s", "Required environment DB_USER is not set.", result)
+	if result.Error() != "required environment DB_USER is not set" {
+		t.Errorf("Expected %s Got: %s", "required environment DB_USER is not set", result)
 	}
 
-	os.Setenv("DB_NAME", "")
+	_ = os.Setenv("DB_NAME", "")
 	conf = new()
 	result = conf.Validate()
-	if result.Error() != "Required environment DB_NAME is not set." {
-		t.Errorf("Expected %s Got: %s", "Required environment DB_NAME is not set.", result)
+	if result.Error() != "required environment DB_NAME is not set" {
+		t.Errorf("Expected %s Got: %s", "required environment DB_NAME is not set", result)
 	}
 }

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -18,7 +18,7 @@ import (
 // NOTE: This may need to be enhanced to support development on different OS.
 func getKubeConfigPath() string {
 	defaultKubePath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	if _, err := os.Stat(defaultKubePath); os.IsNotExist(err) {
+	if _, err := os.Stat(defaultKubePath); os.IsNotExist(err) { // #nosec G703 -- Standard kubeconfig path resolution
 		// set default to empty string if path does not reslove
 		defaultKubePath = ""
 	}

--- a/pkg/database/batch.go
+++ b/pkg/database/batch.go
@@ -78,7 +78,7 @@ func (b *batchWithRetry) sendBatch(items []batchItem) error {
 		if strings.Contains(closeErr.Error(), "unexpected EOF") || strings.Contains(closeErr.Error(), "failed to connect") {
 			b.connError = closeErr
 			klog.Error("Send batch failed because database is unavailable. Won't retry.")
-			return errors.New("Failed to connect to database.")
+			return errors.New("failed to connect to database")
 		}
 		klog.Error("Error closing batch result. ", closeErr)
 		return closeErr

--- a/pkg/database/connection_test.go
+++ b/pkg/database/connection_test.go
@@ -37,7 +37,9 @@ func Test_checkErrorAndRollback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	mockConn.ExpectRollback()
 	e := errors.New("table resources not found")
 	logMessage := "Error commiting delete cluster transaction for cluster: cluster_foo"
@@ -50,7 +52,9 @@ func Test_checkErrorAndRollbackError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	e := errors.New("table resources not found")
 
 	mockConn.ExpectRollback().WillReturnError(e) // Rollback returns error

--- a/pkg/database/dataValidation.go
+++ b/pkg/database/dataValidation.go
@@ -41,7 +41,9 @@ func (dao *DAO) ClusterTotals(ctx context.Context, clusterName string) (resource
 	batch.Queue(edgeCountSql, params...)
 
 	br := dao.pool.SendBatch(ctx, batch)
-	defer br.Close()
+	defer func(br pgx.BatchResults) {
+		_ = br.Close()
+	}(br)
 
 	resourcesRow := br.QueryRow()
 	resourcesErr := resourcesRow.Scan(&resources)

--- a/pkg/database/goquHelper.go
+++ b/pkg/database/goquHelper.go
@@ -17,7 +17,7 @@ func useGoqu(query string, params []interface{}) (q string, p []interface{}, er 
 
 	validateParams := func(expectedParams int) bool {
 		if len(params) != expectedParams {
-			er = fmt.Errorf("Invalid number of params for query [%s]", query)
+			er = fmt.Errorf("invalid number of params for query [%s]", query)
 			return false
 		}
 		return true
@@ -79,7 +79,7 @@ func useGoqu(query string, params []interface{}) (q string, p []interface{}, er 
 			goqu.C("edgetype").Eq(params[2])).ToSQL()
 
 	default:
-		er = fmt.Errorf("Unable to build goqu query for [%s]", query)
+		er = fmt.Errorf("unable to build goqu query for [%s]", query)
 	}
 
 	if er != nil {

--- a/pkg/database/upsertCluster_test.go
+++ b/pkg/database/upsertCluster_test.go
@@ -222,7 +222,9 @@ func Test_DelClusterResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	dao, mockPool := buildMockDAO(t)
 	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, nil)
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -247,7 +249,9 @@ func Test_DelCluster(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	dao, mockPool := buildMockDAO(t)
 	mockPool.EXPECT().BeginTx(context.Background(), pgx.TxOptions{}).Return(mockConn, nil)
 	mockConn.ExpectExec(regexp.QuoteMeta(`DELETE FROM "search"."resources" WHERE (("cluster" = 'name-foo') AND ("uid" != 'cluster__name-foo'))`)).WillReturnResult(pgxmock.NewResult("DELETE", 1))
@@ -279,7 +283,9 @@ func Test_DelClusterResourcesError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	dao, mockPool := buildMockDAO(t)
 
 	// Delete cluster resources and edges
@@ -341,7 +347,9 @@ func Test_GetManagedCluster(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
-	defer mockConn.Close(context.Background())
+	defer func(mockConn pgxmock.PgxConnIface, ctx context.Context) {
+		_ = mockConn.Close(ctx)
+	}(mockConn, context.Background())
 	dao, mockPool := buildMockDAO(t)
 	columns := []string{"cluster"}
 	pgxRows := pgxpoolmock.NewRows(columns).AddRow(clusterName).ToPgxRows()

--- a/pkg/server/healthProbes.go
+++ b/pkg/server/healthProbes.go
@@ -12,11 +12,11 @@ import (
 // LivenessProbe is used to check if this service is alive.
 func LivenessProbe(w http.ResponseWriter, r *http.Request) {
 	klog.V(7).Info("livenessProbe")
-	fmt.Fprint(w, "OK")
+	_, _ = fmt.Fprint(w, "OK")
 }
 
 // ReadinessProbe checks if this service is available.
 func ReadinessProbe(w http.ResponseWriter, r *http.Request) {
 	klog.V(7).Info("readinessProbe")
-	fmt.Fprint(w, "OK")
+	_, _ = fmt.Fprint(w, "OK")
 }

--- a/pkg/testutils/supressConsoleOutput.go
+++ b/pkg/testutils/supressConsoleOutput.go
@@ -14,7 +14,9 @@ func SupressConsoleOutput() func() {
 	os.Stderr = nullFile
 
 	return func() {
-		defer nullFile.Close()
+		defer func(nullFile *os.File) {
+			_ = nullFile.Close()
+		}(nullFile)
 		os.Stderr = stdErr
 	}
 }


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-37648

### Description of changes
Cherry-pick of #713 (merged to `release-2.13`) to `release-2.11`.

`release-2.11` was on Go 1.24 / golangci-lint v1.64.6 (vs. `release-2.13`'s Go 1.25 / golangci-lint v2.4.0 baseline at the time #713 was opened), so the version bumps were adapted to this branch's starting point:

- `go.mod`: 1.24.0 → 1.26.0
- `Dockerfile`: go1.24-linux → go1.26-linux
- `Dockerfile.rhtap`: rhel_9_1.24 → rhel_9_1.26
- `.ci-operator.yaml`: go1.24-linux → go1.26-linux
- `Makefile`, `Makefile.prow`: golangci-lint v1.64.6 → v2.9.0

### Conflict resolution notes
`release-2.11`'s `go.mod`, `Dockerfile.rhtap`, and `Makefile` have diverged from `release-2.13` in unrelated ways (different `replace` directive pins, VCS label build args, a `podman-build` target). A naive "take theirs" resolution would have regressed those unrelated changes onto this branch, so each conflicting file was patched with only the single line this PR intends to change, verified line-by-line against `release-2.11`'s pre-cherry-pick content.

`go mod tidy` under the go1.26 toolchain did not require any `go.sum` or transitive dependency changes for this module's graph.

### Lint fixes (golangci-lint v2.9.0)
`release-2.11` never received the lint corrections that shipped alongside the v1.64.6 → v2.4.0 upgrade on other branches (see #670, a cherry-pick of #666 to `release-2.12`). Since bumping straight to v2.9.0 here surfaces the same class of findings, the code fixes from #670 were ported over:

- `errcheck`: check/discard error returns from deferred `Close()` calls (`mockConn.Close`, `nullFile.Close`, `br.Close`) and `fmt.Fprint`/`os.Setenv` calls in both source and test code.
- `staticcheck` (ST1005): error strings must not be capitalized or end with punctuation (`pkg/config/config.go`, `pkg/database/batch.go`, `pkg/database/goquHelper.go`). Corresponding assertions in `pkg/config/config_test.go` updated to match the new error text.

No golangci-lint config file (`.golangci.yml`) exists in this repo, so no v1→v2 config migration was needed.

### Test plan
- `go build ./...` — passes
- `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass
- `golangci-lint run --timeout=3m` (v2.9.0) — 0 issues