### PR TITLE
security: ACM-42544 — scope all delta-sync mutations to the authenticated cluster

### DIFF
--- a/pkg/database/goquHelper.go
+++ b/pkg/database/goquHelper.go
@@ -72,7 +72,7 @@ func useGoqu(query string, params []interface{}) (q string, p []interface{}, er 
 			Insert().Cols("sourceid", "sourcekind", "destid", "destkind", "edgetype", "cluster").Vals(params).
 			OnConflict(goqu.DoNothing()).ToSQL()
 
-	case "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4":
+	case "DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3 AND cluster=$4":
 		if !validateParams(4) {
 			break
 		}

--- a/pkg/database/goquHelper.go
+++ b/pkg/database/goquHelper.go
@@ -40,12 +40,13 @@ func useGoqu(query string, params []interface{}) (q string, p []interface{}, er 
 			OnConflict(goqu.DoUpdate("uid", goqu.C("data").Set(params[2])).
 				Where(resources.Col("data").Neq(params[2]))).ToSQL()
 
-	case "UPDATE search.resources SET data=$2 WHERE uid=$1":
-		if !validateParams(2) {
+	case "UPDATE search.resources SET data=$2 WHERE uid=$1 AND cluster=$3":
+		if !validateParams(3) {
 			break
 		}
 		q, p, er = dialect.From(resources).Prepared(true).
-			Update().Set(goqu.Record{"data": params[1].(string)}).Where(goqu.C("uid").Eq(params[0])).ToSQL()
+			Update().Set(goqu.Record{"data": params[1].(string)}).
+			Where(goqu.C("uid").Eq(params[0]), goqu.C("cluster").Eq(params[2])).ToSQL()
 
 	case "DELETE from search.resources WHERE cluster=$1 AND uid NOT IN ($2)":
 		q, p, er = dialect.From(resources).
@@ -71,15 +72,16 @@ func useGoqu(query string, params []interface{}) (q string, p []interface{}, er 
 			Insert().Cols("sourceid", "sourcekind", "destid", "destkind", "edgetype", "cluster").Vals(params).
 			OnConflict(goqu.DoNothing()).ToSQL()
 
-	case "DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3":
-		if !validateParams(3) {
+	case "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4":
+		if !validateParams(4) {
 			break
 		}
 		q, p, er = dialect.From(edges).Prepared(true).
 			Delete().Where(
 			goqu.C("sourceid").Eq(params[0]),
 			goqu.C("destid").Eq(params[1]),
-			goqu.C("edgetype").Eq(params[2])).ToSQL()
+			goqu.C("edgetype").Eq(params[2]),
+			goqu.C("cluster").Eq(params[3])).ToSQL()
 
 	default:
 		er = fmt.Errorf("unable to build goqu query for [%s]", query)

--- a/pkg/database/goquHelper.go
+++ b/pkg/database/goquHelper.go
@@ -40,6 +40,16 @@ func useGoqu(query string, params []interface{}) (q string, p []interface{}, er 
 			OnConflict(goqu.DoUpdate("uid", goqu.C("data").Set(params[2])).
 				Where(resources.Col("data").Neq(params[2]))).ToSQL()
 
+	// Cluster-scoped resync variant: only overwrites the row when it belongs to this cluster.
+	case "INSERT into search.resources values($1,$2,$3) ON CONFLICT (uid) DO UPDATE SET data=$3 WHERE r.cluster=$2 AND data!=$3":
+		if !validateParams(3) {
+			break
+		}
+		q, p, er = dialect.From(resources).Prepared(true).
+			Insert().Rows(goqu.Record{"uid": params[0], "cluster": params[1], "data": params[2]}).
+			OnConflict(goqu.DoUpdate("uid", goqu.C("data").Set(params[2])).
+				Where(resources.Col("cluster").Eq(params[1]), resources.Col("data").Neq(params[2]))).ToSQL()
+
 	case "UPDATE search.resources SET data=$2 WHERE uid=$1 AND cluster=$3":
 		if !validateParams(3) {
 			break

--- a/pkg/database/goquHelper_test.go
+++ b/pkg/database/goquHelper_test.go
@@ -51,7 +51,7 @@ func Test_useGoqu_updateResource_wrongParamCount(t *testing.T) {
 // Test that DELETE edges now requires cluster ownership.
 func Test_useGoqu_deleteEdge_clusterScoped(t *testing.T) {
 	q, p, er := useGoqu(
-		"DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
+		"DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3 AND cluster=$4",
 		[]interface{}{"my-cluster/src", "my-cluster/dst", "ownedBy", "my-cluster"})
 
 	assert.Nil(t, er)
@@ -64,7 +64,7 @@ func Test_useGoqu_deleteEdge_clusterScoped(t *testing.T) {
 
 func Test_useGoqu_deleteEdge_wrongParamCount(t *testing.T) {
 	q, p, er := useGoqu(
-		"DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
+		"DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3 AND cluster=$4",
 		[]interface{}{"src", "dst"}) // missing edgeType and cluster
 
 	assert.Equal(t, "", q)

--- a/pkg/database/goquHelper_test.go
+++ b/pkg/database/goquHelper_test.go
@@ -23,3 +23,51 @@ func Test_useGoqu_invalidParams(t *testing.T) {
 	assert.Nil(t, p)
 	assert.NotNil(t, er)
 }
+
+// Test that UPDATE now requires cluster ownership.
+func Test_useGoqu_updateResource_clusterScoped(t *testing.T) {
+	q, p, er := useGoqu(
+		"UPDATE search.resources SET data=$2 WHERE uid=$1 AND cluster=$3",
+		[]interface{}{"my-cluster/abc-123", `{"kind":"Pod"}`, "my-cluster"})
+
+	assert.Nil(t, er)
+	assert.Contains(t, q, `"uid" = `)
+	assert.Contains(t, q, `"cluster" = `)
+	// goqu places SET params before WHERE params in prepared UPDATE statements;
+	// the bound slice order is therefore: [data, uid, cluster].
+	assert.Equal(t, []interface{}{`{"kind":"Pod"}`, "my-cluster/abc-123", "my-cluster"}, p)
+}
+
+func Test_useGoqu_updateResource_wrongParamCount(t *testing.T) {
+	q, p, er := useGoqu(
+		"UPDATE search.resources SET data=$2 WHERE uid=$1 AND cluster=$3",
+		[]interface{}{"uid-only"}) // missing data and cluster
+
+	assert.Equal(t, "", q)
+	assert.Nil(t, p)
+	assert.NotNil(t, er)
+}
+
+// Test that DELETE edges now requires cluster ownership.
+func Test_useGoqu_deleteEdge_clusterScoped(t *testing.T) {
+	q, p, er := useGoqu(
+		"DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
+		[]interface{}{"my-cluster/src", "my-cluster/dst", "ownedBy", "my-cluster"})
+
+	assert.Nil(t, er)
+	assert.Contains(t, q, `"sourceid" = `)
+	assert.Contains(t, q, `"destid" = `)
+	assert.Contains(t, q, `"edgetype" = `)
+	assert.Contains(t, q, `"cluster" = `)
+	assert.Equal(t, []interface{}{"my-cluster/src", "my-cluster/dst", "ownedBy", "my-cluster"}, p)
+}
+
+func Test_useGoqu_deleteEdge_wrongParamCount(t *testing.T) {
+	q, p, er := useGoqu(
+		"DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
+		[]interface{}{"src", "dst"}) // missing edgeType and cluster
+
+	assert.Equal(t, "", q)
+	assert.Nil(t, p)
+	assert.NotNil(t, er)
+}

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -146,7 +146,7 @@ func (dao *DAO) resetEdges(ctx context.Context, clusterName string,
 	// AND cluster=$4 scopes the delete to this cluster's rows only.
 	for _, edge := range existingEdgesMap {
 		query, params, err := useGoqu(
-			"DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
+			"DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3 AND cluster=$4",
 			[]interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType, clusterName})
 		if err == nil {
 			queueErr = batch.Queue(batchItem{

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -196,9 +196,15 @@ func (dao *DAO) upsertResources(ctx context.Context, resyncBody []byte, clusterN
 					return incomingUIDs, resource, fmt.Errorf("error decoding resource from request: %v", err)
 				}
 				uid := resource.UID
+				// Reject UIDs that don't belong to this cluster before they reach the DB.
+				if err := validateUIDPrefix(uid, clusterName); err != nil {
+					klog.Warningf("Rejecting resync resource from cluster [%s]: %v", clusterName, err)
+					syncResponse.AddErrors = append(syncResponse.AddErrors, model.SyncError{ResourceUID: uid, Message: err.Error()})
+					continue
+				}
 				data, _ := json.Marshal(resource.Properties)
 				query, params, err := useGoqu(
-					"INSERT into search.resources values($1,$2,$3) ON CONFLICT (uid) DO UPDATE SET data=$3 WHERE data!=$3",
+					"INSERT into search.resources values($1,$2,$3) ON CONFLICT (uid) DO UPDATE SET data=$3 WHERE r.cluster=$2 AND data!=$3",
 					[]interface{}{uid, clusterName, string(data)})
 				if err == nil {
 					queueErr := batch.Queue(batchItem{

--- a/pkg/database/resync.go
+++ b/pkg/database/resync.go
@@ -143,10 +143,11 @@ func (dao *DAO) resetEdges(ctx context.Context, clusterName string,
 	addErr := addEdges(resyncRequest, &existingEdgesMap, clusterName, syncResponse, &batch)
 
 	// Delete existing edges that are not in the resyncRequest.
+	// AND cluster=$4 scopes the delete to this cluster's rows only.
 	for _, edge := range existingEdgesMap {
 		query, params, err := useGoqu(
-			"DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3",
-			[]interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType})
+			"DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
+			[]interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType, clusterName})
 		if err == nil {
 			queueErr = batch.Queue(batchItem{
 				action: "deleteEdge",

--- a/pkg/database/resync_test.go
+++ b/pkg/database/resync_test.go
@@ -36,7 +36,7 @@ func Test_ResyncData(t *testing.T) {
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	err := dao.ResyncData(context.Background(), "test-cluster", response, dataBytes)
+	err := dao.ResyncData(context.Background(), "local-cluster", response, dataBytes)
 
 	assert.Nil(t, err)
 }
@@ -60,7 +60,7 @@ func Test_ResyncData_errors(t *testing.T) {
 
 	// Execute function test.
 	response := &model.SyncResponse{}
-	err := dao.ResyncData(context.Background(), "test-cluster", response, dataBytes)
+	err := dao.ResyncData(context.Background(), "local-cluster", response, dataBytes)
 
 	assert.NotNil(t, err)
 }
@@ -69,11 +69,11 @@ func Test_CheckHubClusterRenameWithoutChange(t *testing.T) {
 	// Prepare a mock DAO instance
 	dao, mockPool := buildMockDAO(t)
 
-	// Mock Postgres state with existing hub cluster test-cluster
+	// Mock Postgres state with existing hub cluster local-cluster
 	testutils.MockDatabaseState(mockPool)
 
-	// test-cluster is the only cluster to exist in the database, no cleanup should happen
-	err := dao.checkHubClusterRename(context.Background(), "test-cluster")
+	// local-cluster is the only cluster to exist in the database, no cleanup should happen
+	err := dao.checkHubClusterRename(context.Background(), "local-cluster")
 
 	// no further mock queries and old hub cluster cleanup was required
 	assert.Nil(t, err)
@@ -83,20 +83,20 @@ func Test_CheckHubClusterRenameWithChange(t *testing.T) {
 	// Prepare a mock DAO instance
 	dao, mockPool := buildMockDAO(t)
 
-	// Mock Postgres state with existing hub cluster test-cluster
+	// Mock Postgres state with existing hub cluster local-cluster
 	testutils.MockDatabaseState(mockPool)
 
-	// test-cluster gets cleaned up from search.resources
+	// local-cluster gets cleaned up from search.resources
 	mockPool.EXPECT().Exec(gomock.Any(),
-		`DELETE FROM "search"."resources" WHERE ("cluster" = 'test-cluster')`,
+		`DELETE FROM "search"."resources" WHERE ("cluster" = 'local-cluster')`,
 		[]interface{}{}).Return(pgxmock.NewResult("DELETE", 1), nil)
 
-	// test-cluster gets cleaned up from search.edges
+	// local-cluster gets cleaned up from search.edges
 	mockPool.EXPECT().Exec(gomock.Any(),
-		`DELETE FROM "search"."edges" WHERE ("cluster" = 'test-cluster')`,
+		`DELETE FROM "search"."edges" WHERE ("cluster" = 'local-cluster')`,
 		[]interface{}{}).Return(pgxmock.NewResult("DELETE", 1), nil)
 
-	// test-cluster should get cleaned up when we call this with the new hub cluster new-cluster
+	// local-cluster should get cleaned up when we call this with the new hub cluster new-cluster
 	err := dao.checkHubClusterRename(context.Background(), "new-cluster")
 
 	assert.Nil(t, err)
@@ -106,13 +106,13 @@ func Test_HubClusterCleanupWithoutChangeWithRetry(t *testing.T) {
 	// Prepare a mock DAO instance
 	dao, mockPool := buildMockDAO(t)
 
-	// Mock Postgres state with existing hub cluster test-cluster
+	// Mock Postgres state with existing hub cluster local-cluster
 	testutils.MockDatabaseState(mockPool)
 
 	// Mock a failed deletion of search.resources where it succeeds on second attempt
 	retry := 0
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq(
-		`DELETE FROM "search"."resources" WHERE ("cluster" = 'test-cluster')`),
+		`DELETE FROM "search"."resources" WHERE ("cluster" = 'local-cluster')`),
 		[]interface{}{}).Times(2).DoAndReturn(func(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
 		if retry == 0 {
 			retry++
@@ -125,7 +125,7 @@ func Test_HubClusterCleanupWithoutChangeWithRetry(t *testing.T) {
 
 	// Mock a failed deletion of search.edges where it succeeds on second attempt
 	mockPool.EXPECT().Exec(gomock.Any(), gomock.Eq(
-		`DELETE FROM "search"."edges" WHERE ("cluster" = 'test-cluster')`),
+		`DELETE FROM "search"."edges" WHERE ("cluster" = 'local-cluster')`),
 		[]interface{}{}).Times(2).DoAndReturn(func(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
 		if retry == 0 {
 			retry++
@@ -137,12 +137,12 @@ func Test_HubClusterCleanupWithoutChangeWithRetry(t *testing.T) {
 
 	// Mock selecting the distinct hub cluster names 4 times; once per attempt
 	cluster := []string{"cluster"}
-	clusterRows := pgxpoolmock.NewRows(cluster).AddRow("test-cluster").ToPgxRows()
+	clusterRows := pgxpoolmock.NewRows(cluster).AddRow("local-cluster").ToPgxRows()
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
 		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE ("data"?'_hubClusterResource' AND "data"->>'kind' <> 'Cluster')`),
 		[]interface{}{}).Return(clusterRows, nil).Times(4)
 
-	// test-cluster should get cleaned up when we call this with the new hub cluster new-cluster
+	// local-cluster should get cleaned up when we call this with the new hub cluster new-cluster
 	dao.hubClusterCleanUpWithRetry(context.Background(), "new-cluster")
 
 }

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -93,7 +93,7 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 		})
 		queueErr = batch.Queue(batchItem{
 			action: "deleteEdge",
-			query:  fmt.Sprintf("DELETE from search.edges WHERE cluster=$1 AND (sourceId IN (%s) OR destId IN (%s))", paramStr, paramStr),
+			query:  fmt.Sprintf("DELETE from search.edges WHERE cluster=$1 AND (sourceid IN (%s) OR destid IN (%s))", paramStr, paramStr),
 			uid:    fmt.Sprintf("%s", uids),
 			args:   args,
 		})
@@ -120,7 +120,7 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	for _, edge := range event.DeleteEdges {
 		queueErr = batch.Queue(batchItem{
 			action: "deleteEdge",
-			query:  "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
+			query:  "DELETE from search.edges WHERE sourceid=$1 AND destid=$2 AND edgetype=$3 AND cluster=$4",
 			uid:    edge.SourceUID,
 			args:   []interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType, clusterName}})
 	}

--- a/pkg/database/sync.go
+++ b/pkg/database/sync.go
@@ -13,6 +13,17 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// validateUIDPrefix rejects resource UIDs that don't begin with "<clusterName>/".
+// Collector-assigned UIDs always follow this convention. Enforcing it here prevents
+// a spoke from crafting a payload that targets another cluster's rows by uid.
+func validateUIDPrefix(uid, clusterName string) error {
+	prefix := clusterName + "/"
+	if !strings.HasPrefix(uid, prefix) {
+		return fmt.Errorf("uid %q does not start with expected prefix %q", uid, prefix)
+	}
+	return nil
+}
+
 func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	clusterName string, syncResponse *model.SyncResponse) error {
 
@@ -21,13 +32,20 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	var queueErr error
 
 	// ADD RESOURCES
-	// In case of conflict update only if data has changed
+	// In case of conflict update only if data has changed AND the row is owned by this cluster.
+	// The cluster guard on the conflict target prevents a spoke from overwriting another spoke's
+	// row by submitting a resource with a colliding UID.
 	for _, resource := range event.AddResources {
+		if err := validateUIDPrefix(resource.UID, clusterName); err != nil {
+			klog.Warningf("Rejecting addResource from cluster [%s]: %v", clusterName, err)
+			syncResponse.AddErrors = append(syncResponse.AddErrors, model.SyncError{ResourceUID: resource.UID, Message: err.Error()})
+			continue
+		}
 		data, _ := json.Marshal(resource.Properties)
 		queueErr = batch.Queue(batchItem{
 			action: "addResource",
 			query: `INSERT into search.resources as r values($1,$2,$3) ON CONFLICT (uid) 
-			DO UPDATE SET data=$3 WHERE r.uid=$1 and r.data IS DISTINCT FROM $3`,
+			DO UPDATE SET data=$3 WHERE r.uid=$1 AND r.cluster=$2 AND r.data IS DISTINCT FROM $3`,
 			uid:  resource.UID,
 			args: []interface{}{resource.UID, clusterName, string(data)},
 		})
@@ -36,39 +54,48 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	// UPDATE RESOURCES
 	// The collector enforces that a resource isn't added and updated in the same sync event.
 	// The uid and cluster fields will never get updated for a resource.
+	// AND cluster=$3 ensures a spoke can only update rows it owns.
 	for _, resource := range event.UpdateResources {
+		if err := validateUIDPrefix(resource.UID, clusterName); err != nil {
+			klog.Warningf("Rejecting updateResource from cluster [%s]: %v", clusterName, err)
+			syncResponse.UpdateErrors = append(syncResponse.UpdateErrors, model.SyncError{ResourceUID: resource.UID, Message: err.Error()})
+			continue
+		}
 		data, _ := json.Marshal(resource.Properties)
 		queueErr = batch.Queue(batchItem{
 			action: "updateResource",
-			query:  "UPDATE search.resources SET data=$2 WHERE uid=$1",
+			query:  "UPDATE search.resources SET data=$2 WHERE uid=$1 AND cluster=$3",
 			uid:    resource.UID,
-			args:   []interface{}{resource.UID, string(data)},
+			args:   []interface{}{resource.UID, string(data), clusterName},
 		})
 	}
 
 	// DELETE RESOURCES and all edges pointing to the resource.
+	// AND cluster=$N ensures a spoke can only delete its own rows.
 	if len(event.DeleteResources) > 0 {
+		// clusterName occupies $1; UIDs follow as $2, $3, …
 		params := make([]string, len(event.DeleteResources))
 		uids := make([]interface{}, len(event.DeleteResources))
 		for i, resource := range event.DeleteResources {
-			params[i] = fmt.Sprintf("$%d", i+1)
+			params[i] = fmt.Sprintf("$%d", i+2) // $2, $3, … (cluster is $1)
 			uids[i] = resource.UID
 		}
 		paramStr := strings.Join(params, ",")
+		args := append([]interface{}{clusterName}, uids...)
 
 		// TODO: Need better safety for delete errors.
 		// The current retry logic won't work well if there's an error here.
 		err := batch.Queue(batchItem{
 			action: "deleteResource",
-			query:  fmt.Sprintf("DELETE from search.resources WHERE uid IN (%s)", paramStr),
+			query:  fmt.Sprintf("DELETE from search.resources WHERE cluster=$1 AND uid IN (%s)", paramStr),
 			uid:    fmt.Sprintf("%s", uids),
-			args:   uids,
+			args:   args,
 		})
 		queueErr = batch.Queue(batchItem{
-			action: "deleteResource",
-			query:  fmt.Sprintf("DELETE from search.edges WHERE sourceId IN (%s) OR destId IN (%s)", paramStr, paramStr),
+			action: "deleteEdge",
+			query:  fmt.Sprintf("DELETE from search.edges WHERE cluster=$1 AND (sourceId IN (%s) OR destId IN (%s))", paramStr, paramStr),
 			uid:    fmt.Sprintf("%s", uids),
-			args:   uids,
+			args:   args,
 		})
 		if err != nil {
 			queueErr = err
@@ -86,15 +113,16 @@ func (dao *DAO) SyncData(ctx context.Context, event model.SyncEvent,
 	}
 
 	// UPDATE EDGES
-	// Edges are never updated. The collector only sends ADD and DELETE eveents for edges.
+	// Edges are never updated. The collector only sends ADD and DELETE events for edges.
 
 	// DELETE EDGES
+	// AND cluster=$4 ensures a spoke can only delete edges it owns.
 	for _, edge := range event.DeleteEdges {
 		queueErr = batch.Queue(batchItem{
 			action: "deleteEdge",
-			query:  "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3",
+			query:  "DELETE from search.edges WHERE sourceId=$1 AND destId=$2 AND edgeType=$3 AND cluster=$4",
 			uid:    edge.SourceUID,
-			args:   []interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType}})
+			args:   []interface{}{edge.SourceUID, edge.DestUID, edge.EdgeType, clusterName}})
 	}
 
 	// Flush remaining items in the batch.

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -24,7 +24,9 @@ func loadSimpleSyncEvent(t *testing.T) model.SyncEvent {
 	}
 	defer data.Close() //nolint: errcheck
 	var syncEvent model.SyncEvent
-	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
+	if err := json.NewDecoder(data).Decode(&syncEvent); err != nil {
+		t.Fatalf("failed to decode mock sync payload: %v", err)
+	}
 	return syncEvent
 }
 

--- a/pkg/database/sync_test.go
+++ b/pkg/database/sync_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// loadSimpleSyncEvent reads the shared mock sync payload from mocks/simple.json.
+// All UIDs in that file are prefixed with "local-cluster/".
+func loadSimpleSyncEvent(t *testing.T) model.SyncEvent {
+	t.Helper()
+	data, err := os.Open("./mocks/simple.json")
+	if err != nil {
+		t.Fatalf("failed to open mock sync payload: %v", err)
+	}
+	defer data.Close() //nolint: errcheck
+	var syncEvent model.SyncEvent
+	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
+	return syncEvent
+}
+
 func Test_SyncData(t *testing.T) {
 	// Prepare a mock DAO instance
 	dao, mockPool := buildMockDAO(t)
@@ -23,16 +37,10 @@ func Test_SyncData(t *testing.T) {
 	br := &testutils.MockBatchResults{}
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(7)
 
-	// Prepare Request data
-	data, _ := os.Open("./mocks/simple.json")
-	var syncEvent model.SyncEvent
-	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
-
-	// Execute test
+	// UIDs in simple.json are "local-cluster/…", so clusterName must match.
 	response := &model.SyncResponse{}
-	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), loadSimpleSyncEvent(t), "local-cluster", response)
 
-	// Assert
 	assert.Nil(t, err)
 	AssertEqual(t, response.TotalAdded, 2, "Incorrect number of resources added.")
 	AssertEqual(t, response.TotalUpdated, 1, "Incorrect number of resources updated.")
@@ -53,25 +61,21 @@ func Test_Sync_With_Exec_Errors(t *testing.T) {
 	}
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(7)
 
-	// Prepare Request data
-	data, _ := os.Open("./mocks/simple.json")
-	var syncEvent model.SyncEvent
-	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
-
 	// Supress console output to prevent log messages from polluting test output.
 	defer testutils.SupressConsoleOutput()()
 
-	// Execute test
 	response := &model.SyncResponse{}
-	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), loadSimpleSyncEvent(t), "local-cluster", response)
 
-	// Assert
 	assert.Nil(t, err)
 	AssertEqual(t, len(response.AddErrors), 2, "Incorrect number of AddErrors.")
 	AssertEqual(t, len(response.UpdateErrors), 1, "Incorrect number of UpdateErrors.")
-	AssertEqual(t, len(response.DeleteErrors), 2, "Incorrect number of DeleteErrors.")
+	// The resource DELETE (cluster-scoped) is 1 statement → 1 DeleteError.
+	// The accompanying edge DELETE (cluster-scoped) is now categorised as deleteEdge
+	// → counted in DeleteEdgeErrors together with the explicit edge delete below.
+	AssertEqual(t, len(response.DeleteErrors), 1, "Incorrect number of DeleteErrors.")
 	AssertEqual(t, len(response.AddEdgeErrors), 1, "Incorrect number of AddEdgeErrors.")
-	AssertEqual(t, len(response.DeleteEdgeErrors), 1, "Incorrect number of DeleteEdgeErrors.")
+	AssertEqual(t, len(response.DeleteEdgeErrors), 2, "Incorrect number of DeleteEdgeErrors.")
 }
 
 func Test_Sync_With_OnClose_Errors(t *testing.T) {
@@ -85,18 +89,67 @@ func Test_Sync_With_OnClose_Errors(t *testing.T) {
 	}
 	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(7)
 
-	// Prepare Request data
-	data, _ := os.Open("./mocks/simple.json")
-	var syncEvent model.SyncEvent
-	json.NewDecoder(data).Decode(&syncEvent) //nolint: errcheck
-
 	// Supress console output to prevent log messages from polluting test output.
 	defer testutils.SupressConsoleOutput()()
 
-	// Execute test
 	response := &model.SyncResponse{}
-	err := dao.SyncData(context.Background(), syncEvent, "test-cluster", response)
+	err := dao.SyncData(context.Background(), loadSimpleSyncEvent(t), "local-cluster", response)
 
-	// Assert
 	assert.NotNil(t, err)
+}
+
+// --- Security: UID prefix validation ---
+
+// Test_SyncData_RejectsWrongClusterUID verifies that resources whose UIDs belong to
+// a different cluster are silently dropped (logged + error recorded) rather than
+// written to the database. No DB calls should be issued for the rejected items.
+func Test_SyncData_RejectsWrongClusterUID(t *testing.T) {
+	defer testutils.SupressConsoleOutput()()
+
+	dao, mockPool := buildMockDAO(t)
+	dao.batchSize = 10
+
+	// The payload has 2 adds + 1 update with "local-cluster/" UIDs, but we're
+	// sending as "evil-cluster". All three should be rejected before any DB call.
+	// The 1 delete and 1 addEdge / 1 deleteEdge have no UID prefix check (they go
+	// through the bulk SQL path), so 3 batches are still expected.
+	br := &testutils.MockBatchResults{}
+	mockPool.EXPECT().SendBatch(gomock.Any(), gomock.Any()).Return(br).Times(3)
+
+	response := &model.SyncResponse{}
+	err := dao.SyncData(context.Background(), loadSimpleSyncEvent(t), "evil-cluster", response)
+
+	assert.Nil(t, err)
+	// All adds and the update are rejected; none reach the DB.
+	AssertEqual(t, response.TotalAdded, 0, "No resources should be added for wrong-cluster UIDs.")
+	AssertEqual(t, response.TotalUpdated, 0, "No resources should be updated for wrong-cluster UIDs.")
+	AssertEqual(t, len(response.AddErrors), 2, "Expected 2 AddErrors for rejected UIDs.")
+	AssertEqual(t, len(response.UpdateErrors), 1, "Expected 1 UpdateError for rejected UID.")
+}
+
+func Test_validateUIDPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		uid         string
+		clusterName string
+		wantErr     bool
+	}{
+		{"valid prefix", "my-cluster/abc-123", "my-cluster", false},
+		{"valid prefix with nested slash", "my-cluster/ns/kind/name", "my-cluster", false},
+		{"wrong cluster prefix", "other-cluster/abc-123", "my-cluster", true},
+		{"no slash in uid", "abc-123", "my-cluster", true},
+		{"empty uid", "", "my-cluster", true},
+		{"prefix only no slash", "my-cluster", "my-cluster", true},
+		{"empty cluster name", "my-cluster/abc", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateUIDPrefix(tc.uid, tc.clusterName)
+			if tc.wantErr {
+				assert.Error(t, err, "expected an error for uid=%q cluster=%q", tc.uid, tc.clusterName)
+			} else {
+				assert.NoError(t, err, "expected no error for uid=%q cluster=%q", tc.uid, tc.clusterName)
+			}
+		})
+	}
 }

--- a/pkg/server/syncHandler_test.go
+++ b/pkg/server/syncHandler_test.go
@@ -176,7 +176,7 @@ func Test_resyncRequest_withErrorDeletingResources(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
 
 	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
-	request.Header.Set("X-Overwrite-State", "false")
+	request.Header.Set("X-Overwrite-State", "true") // full resync — triggers resource/edge cleanup
 	router := mux.NewRouter()
 
 	// Create server with mock database.

--- a/pkg/server/syncHandler_test.go
+++ b/pkg/server/syncHandler_test.go
@@ -27,7 +27,7 @@ func Test_syncRequest(t *testing.T) {
 	}
 	responseRecorder := httptest.NewRecorder()
 
-	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
 	request.Header.Set("X-Overwrite-State", "false")
 	router := mux.NewRouter()
 
@@ -69,7 +69,7 @@ func Test_syncRequest_withError(t *testing.T) {
 		t.Fatal(readErr)
 	}
 	responseRecorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
 	request.Header.Set("X-Overwrite-State", "false")
 	router := mux.NewRouter()
 
@@ -100,7 +100,7 @@ func Test_syncRequest_withErrorQueryingTotalResources(t *testing.T) {
 		t.Fatal(readErr)
 	}
 	responseRecorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
 	request.Header.Set("X-Overwrite-State", "false")
 	router := mux.NewRouter()
 
@@ -132,7 +132,7 @@ func Test_resyncRequest(t *testing.T) {
 	}
 	responseRecorder := httptest.NewRecorder()
 
-	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
 	request.Header.Set("X-Overwrite-State", "true")
 	router := mux.NewRouter()
 
@@ -175,7 +175,7 @@ func Test_resyncRequest_withErrorDeletingResources(t *testing.T) {
 	}
 	responseRecorder := httptest.NewRecorder()
 
-	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
 	request.Header.Set("X-Overwrite-State", "false")
 	router := mux.NewRouter()
 
@@ -210,7 +210,7 @@ func Test_resyncRequest_withErrorDeletingEdges(t *testing.T) {
 	}
 	responseRecorder := httptest.NewRecorder()
 
-	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
 	request.Header.Set("X-Overwrite-State", "true")
 	router := mux.NewRouter()
 
@@ -242,7 +242,7 @@ func Test_incorrectRequestBody(t *testing.T) {
 
 	responseRecorder := httptest.NewRecorder()
 
-	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/test-cluster/sync", body)
+	request := httptest.NewRequest(http.MethodPost, "/aggregator/clusters/local-cluster/sync", body)
 	router := mux.NewRouter()
 
 	server, _ := buildMockServer(t)

--- a/pkg/testutils/mockDatabaseState.go
+++ b/pkg/testutils/mockDatabaseState.go
@@ -6,21 +6,23 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-// Mocks the existing state of the database for the test-cluster.
+// MockDatabaseState mocks the existing database state for the local-cluster.
+// All mock JSON payloads in pkg/server/mocks/ and pkg/database/mocks/ use "local-cluster/"
+// UIDs, so the mock expectations must match that cluster name.
 func MockDatabaseState(mockPool *pgxpoolmock.MockPgxPool) {
 	columns := []string{"uid", "data"}
 	resourceRows := pgxpoolmock.NewRows(columns).AddRow("uid-123", `{"kind: "mock"}`).ToPgxRows()
 	edgeColumns := []string{"sourceId", "edgeType", "destId"}
 	edgeRows := pgxpoolmock.NewRows(edgeColumns).AddRow("sourceId1", "edgeType1", "destId1").ToPgxRows()
 	cluster := []string{"cluster"}
-	clusterRows := pgxpoolmock.NewRows(cluster).AddRow("test-cluster").ToPgxRows()
+	clusterRows := pgxpoolmock.NewRows(cluster).AddRow("local-cluster").ToPgxRows()
 
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
 		`SELECT "uid", "data" FROM "search"."resources" WHERE (("cluster" = $1) AND ("uid" != $2))`),
-		[]interface{}{"test-cluster", "cluster__test-cluster"}).Return(resourceRows, nil)
+		[]interface{}{"local-cluster", "cluster__local-cluster"}).Return(resourceRows, nil)
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
 		`SELECT "sourceid", "edgetype", "destid" FROM "search"."edges" WHERE (("edgetype" != $1) AND ("cluster" = $2))`),
-		[]interface{}{"interCluster", "test-cluster"}).Return(edgeRows, nil)
+		[]interface{}{"interCluster", "local-cluster"}).Return(edgeRows, nil)
 	mockPool.EXPECT().Query(gomock.Any(), gomock.Eq(
 		`SELECT DISTINCT "cluster" FROM "search"."resources" WHERE ("data"?'_hubClusterResource' AND "data"->>'kind' <> 'Cluster')`),
 		[]interface{}{}).Return(clusterRows, nil)


### PR DESCRIPTION
## Related Issue
https://issues.redhat.com/browse/ACM-42544
CVE: CVE-2026-76827

## Description

Delta-sync write paths did not constrain mutations to rows owned by the requesting `clusterName`. A spoke could craft a payload with UIDs belonging to another cluster and mutate or delete that cluster's indexed data — even when correctly authenticated.

## Changes

### `pkg/database/sync.go`

| Statement | Before | After |
|---|---|---|
| UPDATE resources | `WHERE uid=$1` | `WHERE uid=$1 AND cluster=$3` |
| DELETE resources | `WHERE uid IN (…)` | `WHERE cluster=$1 AND uid IN (…)` |
| DELETE edges (resource path) | `WHERE sourceId IN (…) OR destId IN (…)` | `WHERE cluster=$1 AND (sourceId IN (…) OR destId IN (…))` |
| DELETE edges (per-edge) | `WHERE sourceId=$1 AND destId=$2 AND edgeType=$3` | adds `AND cluster=$4` |
| INSERT ON CONFLICT | update predicate had no cluster check | adds `AND r.cluster=$2` |

New `validateUIDPrefix()` helper rejects any resource UID that does not start with `<clusterName>/` before it reaches the database. Invalid items are recorded in `AddErrors`/`UpdateErrors` and skipped.

### `pkg/database/goquHelper.go`
Switch-case query strings and goqu builders updated to match the new signatures.

### `pkg/database/resync.go`
`resetEdges` delete path updated to the new cluster-scoped query.

### Tests
- `pkg/database/sync_test.go` — `Test_SyncData_RejectsWrongClusterUID` and `Test_validateUIDPrefix` (7 sub-cases); existing tests updated to use `"local-cluster"` matching the mock fixture UIDs.
- `pkg/database/goquHelper_test.go` — `Test_useGoqu_updateResource_clusterScoped` and `Test_useGoqu_deleteEdge_clusterScoped`.
- `pkg/database/resync_test.go`, `pkg/server/syncHandler_test.go`, `pkg/testutils/mockDatabaseState.go` — cluster name aligned to `"local-cluster"` throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted resource and edge updates and deletions to the originating cluster.
  * Prevented synchronization from accepting resource IDs that do not match the submitting cluster.
  * Ensured resynchronization cleanup only removes data belonging to the active cluster.

* **Tests**
  * Added coverage for cluster-scoped database operations, invalid resource IDs, and insufficient query parameters.
  * Updated synchronization and cleanup scenarios to reflect cluster-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->